### PR TITLE
feat: improve web build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,7 +310,7 @@ jobs:
           VERSION: ${{ needs.get-release.outputs.tag_name }}
         run: |
           cd ui/flutter
-          flutter build web
+          flutter build web --web-renderer html
           cd ../../
           cp -r ui/flutter/build/web cmd/web/dist
           mkdir -p dist/zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY ./ui/flutter/pubspec.yaml ./ui/flutter/pubspec.lock ./
 RUN flutter pub get
 COPY ./ui/flutter ./
-RUN flutter build web
+RUN flutter build web --web-renderer html
 
 FROM golang:1.19.3 AS go
 WORKDIR /app


### PR DESCRIPTION
Currently, gopeed is built in canvas mode, which depends on external resources, such as canvasKit.js and font files and css files. If the user’s network environment is not good, it will cause the page font not show. so now it is changed to html mode to build, 
 there is no external resource dependency, and there is no problem in an environment without internet.