### PR TITLE
ci: fix deb desktop entry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,12 +259,9 @@ jobs:
 
           cat>debian/gui/gopeed.desktop<<EOF
           [Desktop Entry]
-          Version=${VERSION:1}
           Name=Gopeed
-          GenericName=Gopeed
+          GenericName=Downloader
           Comment=High speed downloader that supports all platforms.
-          Exec=gopeed
-          Icon=gopeed.png
           Terminal=false
           Type=Application
           Categories=Utility


### PR DESCRIPTION
 - The version key does not represent the version of the application, but rather the version of the desktop entry specification that the file follows. The version field is not required. 
 - The GenericName key is the generic name of the application, such as "Web Browser". 
 - If the Icon key is an absolute path, the given file will be used. If the path is not an absolute path, it should not have a suffix. 
 - Flutter_to_debian adds another Exec and Icon properties to the .desktop file even if there are already Exec and Icon. 
 - By the way: If it seems more standardized for the application's parent directory to use the default /opt than /usr/local/bin, you can use postinst to link /opt/gopeed/gopeed to /usr/bin/gopeed. Flutter_to_debian supports postinst.