### PR TITLE
fix: entrypoint_sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-chown -R ${PUID}:${PGID} /app/Download
+chown -R ${PUID}:${PGID} /app
 
 umask ${UMASK}
 


### PR DESCRIPTION
忘了设置软件数据的权限了，刚刚发现如果设置权限为1000，docker容器无法启动