### PR TITLE
优化镜像大小，优化docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@ RUN CGO_ENABLED=0 go build -tags nosqlite,web \
       -ldflags="-s -w -X github.com/GopeedLab/gopeed/pkg/base.Version=$VERSION -X github.com/GopeedLab/gopeed/pkg/base.InDocker=true" \
       -o dist/gopeed github.com/GopeedLab/gopeed/cmd/web
 
-FROM alpine:3.14.2
+FROM alpine:3.18
 LABEL maintainer="monkeyWie"
 WORKDIR /app
 COPY --from=go /app/dist/gopeed ./
 COPY entrypoint.sh ./entrypoint.sh
 RUN apk update && \
-    apk upgrade --no-cache && \
-    apk add --no-cache bash su-exec; \
+    apk add --no-cache --virtual .build-deps su-exec ; \
     chmod +x ./entrypoint.sh && \
+    apk del .build-deps && \
     rm -rf /var/cache/apk/*
 VOLUME ["/app/storage"]
 ENV PUID=0 PGID=0 UMASK=022

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-version: '3'
-
 services:
-  gopeed:
-    container_name: gopeed
-    ports:
-      - "9999:9999" # HTTP port (host:container)
-    image: liwei2633/gopeed
-    volumes:
-      - ~/gopeed/Downloads:/app/Downloads # mount download path
-      #- ~/gopeed/storage:/app/storage # if you need to mount storage path, uncomment this line
-    restart: unless-stopped
+    gopeed:
+      container_name: gopeed
+      ports:
+        - 9999:9999 # HTTP port (host:container)
+      environment:
+        - PUID=0
+        - PGID=0
+        - UMASK=022
+      volumes:
+        - ~/gopeed/Downloads:/app/Downloads # mount download path
+        #- ~/gopeed/storage:/app/storage # if you need to mount storage path, uncomment this line
+      restart: unless-stopped
+      image: liwei2633/gopeed
+      # command: -u Username -p Password # optional authentication


### PR DESCRIPTION
实测构建下来镜像缩小了大约5MB，升级了基础镜像alpine版本，给docker-compose优化了顺序，增加了一些选项