### PR TITLE
feat: optimize docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,13 @@ RUN CGO_ENABLED=0 go build -tags nosqlite,web \
       -ldflags="-s -w -X github.com/GopeedLab/gopeed/pkg/base.Version=$VERSION -X github.com/GopeedLab/gopeed/pkg/base.InDocker=true" \
       -o dist/gopeed github.com/GopeedLab/gopeed/cmd/web
 
-FROM alpine:3.14.2
+FROM alpine:3.18
 LABEL maintainer="monkeyWie"
 WORKDIR /app
 COPY --from=go /app/dist/gopeed ./
 COPY entrypoint.sh ./entrypoint.sh
 RUN apk update && \
-    apk upgrade --no-cache && \
-    apk add --no-cache bash su-exec; \
+    apk add --no-cache su-exec ; \
     chmod +x ./entrypoint.sh && \
     rm -rf /var/cache/apk/*
 VOLUME ["/app/storage"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-version: '3'
-
 services:
-  gopeed:
-    container_name: gopeed
-    ports:
-      - "9999:9999" # HTTP port (host:container)
-    image: liwei2633/gopeed
-    volumes:
-      - ~/gopeed/Downloads:/app/Downloads # mount download path
-      #- ~/gopeed/storage:/app/storage # if you need to mount storage path, uncomment this line
-    restart: unless-stopped
+    gopeed:
+      container_name: gopeed
+      ports:
+        - 9999:9999 # HTTP port (host:container)
+      environment:
+        - PUID=0
+        - PGID=0
+        - UMASK=022
+      volumes:
+        - ~/gopeed/Downloads:/app/Downloads # mount download path
+        #- ~/gopeed/storage:/app/storage # if you need to mount storage path, uncomment this line
+      restart: unless-stopped
+      image: liwei2633/gopeed
+      # command: -u Username -p Password # optional authentication


### PR DESCRIPTION
实测构建下来镜像缩小了大约5MB，升级了基础镜像alpine版本，给docker-compose优化了顺序，增加了一些选项[
![屏幕截图 2024-11-27 130836](https://github.com/user-attachments/assets/28c40407-544d-4125-abce-440a2411d867)
](url)