### PR TITLE
feat: Open in Folder with support for 3rd file manager

### DIFF
--- a/ui/flutter/lib/util/file_explorer.dart
+++ b/ui/flutter/lib/util/file_explorer.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
-
+import 'package:open_dir/open_dir.dart';
+import 'package:path/path.dart' as path;
 import 'package:url_launcher/url_launcher_string.dart';
 
 class FileExplorer {
@@ -17,7 +18,10 @@ class FileExplorer {
 
   static Future<void> _openFile(String filePath) async {
     if (Platform.isWindows) {
-      Process.run('explorer.exe', ['/select,', filePath]);
+      final fileName = path.basename(filePath);
+      final parentPath = path.dirname(filePath);
+      await OpenDir()
+          .openNativeDir(path: parentPath, highlightedFileName: fileName);
     } else if (Platform.isMacOS) {
       Process.run('open', ['-R', filePath]);
     } else if (Platform.isLinux) {

--- a/ui/flutter/pubspec.lock
+++ b/ui/flutter/pubspec.lock
@@ -723,6 +723,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  open_dir:
+    dependency: "direct main"
+    description:
+      name: open_dir
+      sha256: a4884b00e5e5795a9b4b3d582ac6a66e9196795ed760dbc3c63b4837c70c5901
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
+  open_dir_linux:
+    dependency: transitive
+    description:
+      name: open_dir_linux
+      sha256: "566cd9e02403971be06af35e1abc8057a4f3f98888c1226042e96a2af333b8bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
+  open_dir_macos:
+    dependency: transitive
+    description:
+      name: open_dir_macos
+      sha256: "51fdc8c3a06c9d571b599b5901045ada23d1440b24c3052c0a66cf3ee4ac901b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
+  open_dir_platform_interface:
+    dependency: transitive
+    description:
+      name: open_dir_platform_interface
+      sha256: ca189abb02d8e3320f9b2493b6d58e3a33f393d5eb4ccbbef02e0bc0fd393872
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
+  open_dir_windows:
+    dependency: transitive
+    description:
+      name: open_dir_windows
+      sha256: ec48df32ce61adb6f6cede0330d13b0d89714d2ee2df198f32ecd520e3a5d250
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2+1"
   open_filex:
     dependency: "direct main"
     description:

--- a/ui/flutter/pubspec.yaml
+++ b/ui/flutter/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   win32_registry: ^1.1.5
   share_handler: ^0.0.22
   crypto: ^3.0.6
+  open_dir: ^0.0.2+1
   install_plugin:
     git:
       url: https://github.com/hui-z/flutter_install_plugin.git


### PR DESCRIPTION
When File Open in Folder, support 3rd file manager as system default, such as Directory Opus, etc
The code refers to [localsend](https://github.com/Minessential/localsend_fluent/blob/ec6c3a5464e4b7904e9842bcc61cd0e2a8f44ec5/app/lib/util/native/open_folder.dart#L27)