### PR TITLE
feat: update storage directory path for Windows

### DIFF
--- a/ui/flutter/lib/util/util.dart
+++ b/ui/flutter/lib/util/util.dart
@@ -54,7 +54,8 @@ class Util {
   static Future<void> initStorageDir() async {
     var storageDir = "";
     if (Util.isWindows()) {
-      storageDir = File(Platform.resolvedExecutable).parent.path;
+      storageDir =
+          path.join(File(Platform.resolvedExecutable).parent.path, "storage");
     } else if (!Util.isWeb()) {
       if (Util.isLinux()) {
         storageDir = File(Platform.resolvedExecutable).parent.path;


### PR DESCRIPTION
Fixed: https://github.com/GopeedLab/gopeed/issues/1044

This PR includes breaking changes because it has moved the persistent directories. If need to keep the old data,  you will need to manually move the `gopeed.db`, `database.hive`, `database.lock` files, and the `extensions folder`  from the application's main directory to the `./storage` directory.