### PR TITLE
fix: defect in extension process during rename duplicate file (#1158)

### DIFF
--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -50,12 +50,17 @@ func CheckDuplicateAndRename(path string) (string, error) {
 		return "", err
 	}
 
-	index := strings.LastIndex(name, ".")
+	ext := syspath.Ext(name)
 	var nameTpl string
-	if index == -1 {
+	// Special case: if the extension is the entire filename (like .gitignore),
+	// or if index of last dot is 0 (starts with dot), treat it as no extension
+	if ext == "" || ext == name || (len(ext) > 0 && strings.LastIndex(name, ".") == 0) {
+		// No extension or hidden file without extension
 		nameTpl = name + " (%d)"
 	} else {
-		nameTpl = name[:index] + " (%d)" + name[index:]
+		// Has extension
+		nameWithoutExt := name[:len(name)-len(ext)]
+		nameTpl = nameWithoutExt + " (%d)" + ext
 	}
 	for i := 1; ; i++ {
 		newName := fmt.Sprintf(nameTpl, i)

--- a/pkg/util/path_test.go
+++ b/pkg/util/path_test.go
@@ -106,13 +106,28 @@ func TestSafeRemove(t *testing.T) {
 }
 
 func TestCheckDuplicateAndRename(t *testing.T) {
+	// Test with extension
 	doCheckDuplicateAndRename(t, []string{}, "a.txt", "a.txt")
 	doCheckDuplicateAndRename(t, []string{"a.txt"}, "a.txt", "a (1).txt")
 	doCheckDuplicateAndRename(t, []string{"a.txt", "a (1).txt"}, "a.txt", "a (2).txt")
 
+	// Test without extension
 	doCheckDuplicateAndRename(t, []string{}, "a", "a")
 	doCheckDuplicateAndRename(t, []string{"a"}, "a", "a (1)")
 	doCheckDuplicateAndRename(t, []string{"a", "a (1)"}, "a", "a (2)")
+
+	// Test hidden files (starting with dot)
+	doCheckDuplicateAndRename(t, []string{}, ".gitignore", ".gitignore")
+	doCheckDuplicateAndRename(t, []string{".gitignore"}, ".gitignore", ".gitignore (1)")
+	doCheckDuplicateAndRename(t, []string{".gitignore", ".gitignore (1)"}, ".gitignore", ".gitignore (2)")
+
+	// Test hidden files with extension
+	doCheckDuplicateAndRename(t, []string{}, ".config.json", ".config.json")
+	doCheckDuplicateAndRename(t, []string{".config.json"}, ".config.json", ".config (1).json")
+
+	// Test multiple dots
+	doCheckDuplicateAndRename(t, []string{}, "test.tar.gz", "test.tar.gz")
+	doCheckDuplicateAndRename(t, []string{"test.tar.gz"}, "test.tar.gz", "test.tar (1).gz")
 }
 
 func doCheckDuplicateAndRename(t *testing.T, exitsPaths []string, path string, except string) {


### PR DESCRIPTION
Fix: #1158 
下载没有扩展名的文件时也可以进行自动重命名

Web端测试：
<img width="593" height="455" alt="image" src="https://github.com/user-attachments/assets/734b125c-84ba-41b0-80b6-f501a992c7b5" />

 本地下载目录：
<img width="643" height="92" alt="image" src="https://github.com/user-attachments/assets/90c5d1f7-a109-40d4-8946-1fdd40b884bb" />
