### PR TITLE
fix: modified the isCreate condition to include DownloadStatusWait status

### DIFF
--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -1016,7 +1016,7 @@ func (d *Downloader) doStart(task *Task) (err error) {
 			d.Logger.Error().Stack().Err(err).Msgf("restore fetcher failed, task id: %s", task.ID)
 			return
 		}
-		isCreate = task.Status == base.DownloadStatusReady
+		isCreate = task.Status == base.DownloadStatusReady || task.Status == base.DownloadStatusWait
 		task.updateStatus(base.DownloadStatusRunning)
 
 		return


### PR DESCRIPTION
Fix: #1173 

Modified the `isCreate` condition in `pkg/download/downloader.go` to include `DownloadStatusWait` status, ensuring that duplicate file name checking and renaming logic is triggered for both initial downloads (Ready status) and subsequent batch downloads (Wait status). 

This fix #1173 where **only the first 5 files would be renamed on conflict**, while subsequent batch files would fail to check for existing files and potentially overwrite them.

Screenshot shows that duplicate file name have been correctly renamed:
<img width="610" height="1131" alt="image" src="https://github.com/user-attachments/assets/54a2c7eb-73db-4135-8751-fdaa66ca9a98" />

Screenshot of the local download path:
<img width="658" height="649" alt="image" src="https://github.com/user-attachments/assets/0f3f51ed-f563-421c-a6ab-524b77463e40" />
