### PR TITLE
feat: open data directory on iOS

### DIFF
--- a/ui/flutter/ios/Runner/Info.plist
+++ b/ui/flutter/ios/Runner/Info.plist
@@ -104,5 +104,7 @@
 		<!-- Add for share_handler end -->
 		<key>UIFileSharingEnabled</key>
 		<true/>
+		<key>LSSupportsOpeningDocumentsInPlace</key>
+		<true/>
 	</dict>
 </plist>

--- a/ui/flutter/ios/Runner/Info.plist
+++ b/ui/flutter/ios/Runner/Info.plist
@@ -102,5 +102,7 @@
 		</array>
 
 		<!-- Add for share_handler end -->
+		<key>UIFileSharingEnabled</key>
+		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
This change enables the Documents folder of gopeed on iOS to be visible in the Files app via the local File Provider, making it easier to manage downloaded files
<img width="1180" height="820" alt="IMG_0433" src="https://github.com/user-attachments/assets/3688880e-1e27-4e1f-92e9-d1c55b651411" />
