### PR TITLE
fix: report disk-full errors and harden download lifecycles

### DIFF
--- a/internal/protocol/bt/fetcher.go
+++ b/internal/protocol/bt/fetcher.go
@@ -24,12 +24,147 @@ import (
 )
 
 var (
-	cfg       *torrent.ClientConfig
-	client    *torrent.Client
-	lock      sync.Mutex
-	closeCtx  context.Context
-	closeFunc func()
+	cfg    *torrent.ClientConfig
+	client *torrent.Client
+	lock   sync.Mutex
+	// torrentLifecycleLock serializes client use with subscriber registration,
+	// last-owner Drop, and client shutdown.
+	torrentLifecycleLock sync.Mutex
+	closeCtx             context.Context
+	closeFunc            func()
+
+	writeErrorSubscribers = struct {
+		sync.Mutex
+		byTorrent map[*torrent.Torrent]map[*Fetcher]struct{}
+		errorOps  map[*torrent.Torrent]*torrentWriteErrorOp
+	}{
+		byTorrent: make(map[*torrent.Torrent]map[*Fetcher]struct{}),
+		errorOps:  make(map[*torrent.Torrent]*torrentWriteErrorOp),
+	}
 )
+
+type torrentWriteErrorOp struct {
+	sync.Mutex
+	epoch uint64
+}
+
+func registerTorrentWriteError(t *torrent.Torrent, f *Fetcher) *torrentWriteErrorOp {
+	if t == nil || f == nil {
+		return nil
+	}
+	writeErrorSubscribers.Lock()
+	errorOp := writeErrorSubscribers.errorOps[t]
+	if errorOp == nil {
+		errorOp = &torrentWriteErrorOp{}
+		writeErrorSubscribers.errorOps[t] = errorOp
+	}
+	subscribers := writeErrorSubscribers.byTorrent[t]
+	if subscribers == nil {
+		subscribers = make(map[*Fetcher]struct{})
+		writeErrorSubscribers.byTorrent[t] = subscribers
+		t.SetOnWriteChunkError(func(err error) {
+			dispatchTorrentWriteError(t, errorOp, 0, err)
+		})
+	}
+	subscribers[f] = struct{}{}
+	writeErrorSubscribers.Unlock()
+	return errorOp
+}
+
+func unregisterTorrentWriteError(t *torrent.Torrent, f *Fetcher) (last bool) {
+	if t == nil || f == nil {
+		return false
+	}
+	writeErrorSubscribers.Lock()
+	if subscribers := writeErrorSubscribers.byTorrent[t]; subscribers != nil {
+		delete(subscribers, f)
+		if len(subscribers) == 0 {
+			delete(writeErrorSubscribers.byTorrent, t)
+			delete(writeErrorSubscribers.errorOps, t)
+			last = true
+		}
+	}
+	writeErrorSubscribers.Unlock()
+	return last
+}
+
+func dispatchTorrentWriteError(t *torrent.Torrent, errorOp *torrentWriteErrorOp, epoch uint64, err error) {
+	if t == nil || err == nil {
+		return
+	}
+	writeErrorSubscribers.Lock()
+	registeredOp := writeErrorSubscribers.errorOps[t]
+	writeErrorSubscribers.Unlock()
+	if errorOp == nil || registeredOp != errorOp {
+		return
+	}
+	errorOp.Lock()
+	defer errorOp.Unlock()
+
+	writeErrorSubscribers.Lock()
+	subscribers := make([]*Fetcher, 0, len(writeErrorSubscribers.byTorrent[t]))
+	for subscriber := range writeErrorSubscribers.byTorrent[t] {
+		subscribers = append(subscribers, subscriber)
+	}
+	writeErrorSubscribers.Unlock()
+	eligible := make([]*Fetcher, 0, len(subscribers))
+	hasNewerRun := false
+	for _, subscriber := range subscribers {
+		if subscriber.downloadRunIsNewerThan(epoch) {
+			hasNewerRun = true
+			continue
+		}
+		if subscriber.downloadRunAccepts(epoch) {
+			eligible = append(eligible, subscriber)
+		}
+	}
+	if len(eligible) == 0 {
+		return
+	}
+
+	// Installing a callback replaces anacrolix/torrent's default handler.
+	// Stop the shared torrent before notifying waiters. If one subscriber has
+	// already started a newer generation, restore data flow for that run after
+	// the older generations have been failed.
+	t.DisallowDataDownload()
+	for _, subscriber := range eligible {
+		subscriber.reportWriteChunkError(epoch, err)
+	}
+	if hasNewerRun {
+		t.AllowDataDownload()
+	}
+}
+
+type torrentDownloadRun struct {
+	generation   uint64
+	torrentEpoch uint64
+	errCh        chan error
+	failed       atomic.Bool
+}
+
+func mergeTrackerTiers(lists ...[][]string) [][]string {
+	seen := make(map[string]struct{})
+	merged := make([][]string, 0)
+	for _, list := range lists {
+		for _, tier := range list {
+			uniqueTier := make([]string, 0, len(tier))
+			for _, tracker := range tier {
+				if tracker == "" {
+					continue
+				}
+				if _, ok := seen[tracker]; ok {
+					continue
+				}
+				seen[tracker] = struct{}{}
+				uniqueTier = append(uniqueTier, tracker)
+			}
+			if len(uniqueTier) > 0 {
+				merged = append(merged, uniqueTier)
+			}
+		}
+	}
+	return merged
+}
 
 type Fetcher struct {
 	ctl    *controller.Controller
@@ -44,6 +179,14 @@ type Fetcher struct {
 	torrentDropCtx  context.Context
 	torrentDropFunc func()
 	uploadDoneCh    chan any
+	downloadRunMu   sync.Mutex
+	downloadRun     *torrentDownloadRun
+	runChangedCh    chan struct{}
+	nextGeneration  uint64
+	writeErrorOp    *torrentWriteErrorOp
+	closed          atomic.Bool
+	closeOnce       sync.Once
+	closeErr        error
 }
 
 func (f *Fetcher) Setup(ctl *controller.Controller) {
@@ -55,6 +198,7 @@ func (f *Fetcher) Setup(ctl *controller.Controller) {
 		f.data = &fetcherData{}
 	}
 	f.uploadDoneCh = make(chan any, 1)
+	f.runChangedCh = make(chan struct{})
 	f.torrentDropCtx, f.torrentDropFunc = context.WithCancel(context.Background())
 	f.ctl.GetConfig(&f.config)
 	return
@@ -110,6 +254,37 @@ func (f *Fetcher) Start() (err error) {
 			return
 		}
 	}
+	torrentLifecycleLock.Lock()
+	defer torrentLifecycleLock.Unlock()
+	if f.closed.Load() {
+		return fmt.Errorf("bt fetcher is closed")
+	}
+	if f.writeErrorOp != nil {
+		f.writeErrorOp.Lock()
+		defer f.writeErrorOp.Unlock()
+		f.writeErrorOp.epoch++
+	}
+	f.downloadRunMu.Lock()
+	f.nextGeneration++
+	run := &torrentDownloadRun{
+		generation: f.nextGeneration,
+		errCh:      make(chan error, 1),
+	}
+	if f.writeErrorOp != nil {
+		run.torrentEpoch = f.writeErrorOp.epoch
+		errorOp := f.writeErrorOp
+		epoch := run.torrentEpoch
+		activeTorrent := f.torrent
+		activeTorrent.SetOnWriteChunkError(func(err error) {
+			dispatchTorrentWriteError(activeTorrent, errorOp, epoch, err)
+		})
+	}
+	if f.runChangedCh != nil {
+		close(f.runChangedCh)
+	}
+	f.runChangedCh = make(chan struct{})
+	f.downloadRun = run
+	f.downloadRunMu.Unlock()
 
 	files := f.torrent.Files()
 	// If the user does not specify the file to download, all files will be downloaded by default
@@ -135,18 +310,43 @@ func (f *Fetcher) Start() (err error) {
 }
 
 func (f *Fetcher) Pause() (err error) {
+	torrentLifecycleLock.Lock()
+	defer torrentLifecycleLock.Unlock()
+	if f.closed.Load() {
+		return nil
+	}
+	if f.writeErrorOp != nil {
+		f.writeErrorOp.Lock()
+		defer f.writeErrorOp.Unlock()
+	}
 	f.torrent.DisallowDataDownload()
 	return
 }
 
 func (f *Fetcher) Close() (err error) {
-	f.safeDrop()
-	f.torrentDropFunc()
-	f.uploadDoneCh <- nil
-	if len(client.Torrents()) == 0 {
-		err = closeClient()
-	}
-	return nil
+	f.closeOnce.Do(func() {
+		torrentLifecycleLock.Lock()
+		defer torrentLifecycleLock.Unlock()
+		f.closed.Store(true)
+		if f.writeErrorOp != nil {
+			f.writeErrorOp.Lock()
+			defer f.writeErrorOp.Unlock()
+		}
+		if unregisterTorrentWriteError(f.torrent, f) {
+			f.safeDrop()
+		}
+		if f.torrentDropFunc != nil {
+			f.torrentDropFunc()
+		}
+		if f.uploadDoneCh != nil {
+			select {
+			case f.uploadDoneCh <- nil:
+			default:
+			}
+		}
+		f.closeErr = closeClientIfIdle()
+	})
+	return f.closeErr
 }
 
 func (f *Fetcher) safeDrop() {
@@ -193,10 +393,25 @@ func (f *Fetcher) Progress() fetcher.Progress {
 
 func (f *Fetcher) Wait() (err error) {
 	for {
+		f.downloadRunMu.Lock()
+		run := f.downloadRun
+		runChangedCh := f.runChangedCh
+		f.downloadRunMu.Unlock()
+		var runErrCh <-chan error
+		if run != nil {
+			runErrCh = run.errCh
+		}
 		select {
 		case <-f.torrentDropCtx.Done():
 			return
+		case <-runChangedCh:
+			continue
+		case err := <-runErrCh:
+			return err
 		case <-time.After(time.Second):
+			if run != nil && run.failed.Load() {
+				continue
+			}
 			if f.torrentReady.Load() && len(f.meta.Opts.SelectFiles) > 0 {
 				if f.isDone() {
 					// remove unselected files
@@ -391,10 +606,10 @@ func (f *Fetcher) WaitUpload() (err error) {
 }
 
 func (f *Fetcher) addTorrent(req *base.Request, fromUpload bool) (err error) {
-	if err = base.ParseReqExtra[bt.ReqExtra](req); err != nil {
-		return
+	if f.closed.Load() {
+		return fmt.Errorf("bt fetcher is closed")
 	}
-	if err = f.initClient(); err != nil {
+	if err = base.ParseReqExtra[bt.ReqExtra](req); err != nil {
 		return
 	}
 	schema := util.ParseSchema(req.URL)
@@ -407,6 +622,7 @@ func (f *Fetcher) addTorrent(req *base.Request, fromUpload bool) (err error) {
 		}
 	} else {
 		var reader io.Reader
+		var readerCloser io.Closer
 		if schema == "FILE" {
 			fileUrl, _ := url.Parse(req.URL)
 			filePath := fileUrl.Path[1:]
@@ -414,6 +630,7 @@ func (f *Fetcher) addTorrent(req *base.Request, fromUpload bool) (err error) {
 			if err != nil {
 				return
 			}
+			readerCloser = reader.(io.Closer)
 		} else if schema == "DATA" {
 			_, data := util.ParseDataUri(req.URL)
 			reader = bytes.NewBuffer(data)
@@ -422,7 +639,10 @@ func (f *Fetcher) addTorrent(req *base.Request, fromUpload bool) (err error) {
 			if err != nil {
 				return
 			}
-			defer reader.(io.Closer).Close()
+			readerCloser = reader.(io.Closer)
+		}
+		if readerCloser != nil {
+			defer readerCloser.Close()
 		}
 
 		var metaInfo *metainfo.MetaInfo
@@ -446,47 +666,118 @@ func (f *Fetcher) addTorrent(req *base.Request, fromUpload bool) (err error) {
 			return
 		}
 	}
+	// Tracker announcers are started as part of AddTorrentSpec. Include every
+	// tracker known at creation time so no live tracker state has to be mutated.
+	// anacrolix/torrent currently races internally when trackers are modified on
+	// an existing torrent while an announce attempt is still winding down.
+	if !privateTorrent {
+		extraTrackers := make([][]string, 0)
+		if req.Extra != nil {
+			extra := req.Extra.(*bt.ReqExtra)
+			for _, tracker := range extra.Trackers {
+				extraTrackers = append(extraTrackers, []string{tracker})
+			}
+		}
+		for _, tracker := range f.config.Trackers {
+			extraTrackers = append(extraTrackers, []string{tracker})
+		}
+		spec.Trackers = mergeTrackerTiers(spec.Trackers, extraTrackers)
+	}
+	torrentLifecycleLock.Lock()
+	if f.closed.Load() {
+		torrentLifecycleLock.Unlock()
+		return fmt.Errorf("bt fetcher is closed")
+	}
+	if err = f.initClient(); err != nil {
+		torrentLifecycleLock.Unlock()
+		return
+	}
+
 	spec.Storage = storage.NewFileOpts(storage.NewFileClientOpts{
 		ClientBaseDir: cfg.DataDir,
 		TorrentDirMaker: func(baseDir string, info *metainfo.Info, infoHash metainfo.Hash) string {
 			return f.meta.Opts.Path
 		},
 	})
-	f.torrent, _, err = client.AddTorrentSpec(spec)
+	previousTorrent := f.torrent
+	if existing, ok := client.Torrent(spec.InfoHash); spec.InfoHash != (metainfo.Hash{}) && ok {
+		// Merge every field except trackers. Changing trackers on a live torrent
+		// races inside anacrolix's announce dispatcher; the existing tracker set
+		// remains intact while webseeds, sources, peers and metadata are merged.
+		mergeSpec := *spec
+		mergeSpec.Trackers = nil
+		f.torrent = existing
+		err = existing.MergeSpec(&mergeSpec)
+	} else {
+		f.torrent, _, err = client.AddTorrentSpec(spec)
+	}
 	if err != nil {
+		torrentLifecycleLock.Unlock()
 		return
 	}
-
-	// Do not add external tracker to a private torrent.
-	if !privateTorrent {
-		// use map to deduplicate
-		trackers := make(map[string]bool)
-		if req.Extra != nil {
-			extra := req.Extra.(*bt.ReqExtra)
-			if len(extra.Trackers) > 0 {
-				for _, tracker := range extra.Trackers {
-					trackers[tracker] = true
-				}
-			}
+	if previousTorrent != nil && previousTorrent != f.torrent {
+		if f.writeErrorOp != nil {
+			f.writeErrorOp.Lock()
 		}
-		if len(f.config.Trackers) > 0 {
-			for _, tracker := range f.config.Trackers {
-				trackers[tracker] = true
-			}
+		if unregisterTorrentWriteError(previousTorrent, f) {
+			previousTorrent.Drop()
 		}
-		if len(trackers) > 0 {
-			announceList := make([][]string, 0)
-			for tracker := range trackers {
-				announceList = append(announceList, []string{tracker})
-			}
-			f.torrent.AddTrackers(announceList)
+		if f.writeErrorOp != nil {
+			f.writeErrorOp.Unlock()
 		}
 	}
+	f.writeErrorOp = registerTorrentWriteError(f.torrent, f)
+	torrentLifecycleLock.Unlock()
 	<-f.torrent.GotInfo()
 	f.torrentReady.Store(true)
 
 	go f.doUpload(fromUpload)
 	return
+}
+
+func (f *Fetcher) handleWriteChunkError(err error) {
+	if err == nil {
+		return
+	}
+	torrentLifecycleLock.Lock()
+	errorOp := f.writeErrorOp
+	activeTorrent := f.torrent
+	torrentLifecycleLock.Unlock()
+	if errorOp == nil || activeTorrent == nil {
+		return
+	}
+	errorOp.Lock()
+	epoch := errorOp.epoch
+	errorOp.Unlock()
+	dispatchTorrentWriteError(activeTorrent, errorOp, epoch, err)
+}
+
+func (f *Fetcher) downloadRunAccepts(epoch uint64) bool {
+	f.downloadRunMu.Lock()
+	defer f.downloadRunMu.Unlock()
+	return f.downloadRun != nil && f.downloadRun.torrentEpoch <= epoch && !f.downloadRun.failed.Load()
+}
+
+func (f *Fetcher) downloadRunIsNewerThan(epoch uint64) bool {
+	f.downloadRunMu.Lock()
+	defer f.downloadRunMu.Unlock()
+	return f.downloadRun != nil && f.downloadRun.torrentEpoch > epoch
+}
+
+func (f *Fetcher) reportWriteChunkError(epoch uint64, err error) {
+	if err == nil {
+		return
+	}
+	f.downloadRunMu.Lock()
+	run := f.downloadRun
+	f.downloadRunMu.Unlock()
+	if run == nil || run.torrentEpoch > epoch || !run.failed.CompareAndSwap(false, true) {
+		return
+	}
+	select {
+	case run.errCh <- fmt.Errorf("write torrent data: %w", err):
+	default:
+	}
 }
 
 func (f *Fetcher) seedRadio() float64 {
@@ -511,9 +802,23 @@ type fetcherData struct {
 }
 
 func closeClient() error {
+	torrentLifecycleLock.Lock()
+	defer torrentLifecycleLock.Unlock()
 	lock.Lock()
 	defer lock.Unlock()
+	return closeClientLocked()
+}
 
+func closeClientIfIdle() error {
+	lock.Lock()
+	defer lock.Unlock()
+	if client != nil && len(client.Torrents()) != 0 {
+		return nil
+	}
+	return closeClientLocked()
+}
+
+func closeClientLocked() error {
 	if closeFunc != nil {
 		closeFunc()
 	}

--- a/internal/protocol/bt/fetcher_test.go
+++ b/internal/protocol/bt/fetcher_test.go
@@ -3,12 +3,17 @@ package bt
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	gohttp "net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/GopeedLab/gopeed/internal/controller"
 	"github.com/GopeedLab/gopeed/internal/fetcher"
@@ -18,11 +23,12 @@ import (
 )
 
 func TestFetcher_Resolve_Torrent(t *testing.T) {
-	doResolve(t, buildFetcher())
+	doResolve(t, buildFetcher)
 }
 
 func TestFetcher_Resolve_DataUri_Torrent(t *testing.T) {
 	fetcher := buildFetcher()
+	t.Cleanup(func() { _ = fetcher.Close() })
 	buf, err := os.ReadFile("./testdata/ubuntu-22.04-live-server-amd64.iso.torrent")
 	if err != nil {
 		t.Fatal(err)
@@ -52,8 +58,177 @@ func TestFetcher_Resolve_DataUri_Torrent(t *testing.T) {
 	}
 }
 
+func TestFetcherSurfacesChunkWriteError(t *testing.T) {
+	f := buildFetcher().(*Fetcher)
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Resolve(&base.Request{URL: "./testdata/test.torrent"}, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Start(); err != nil {
+		t.Fatal(err)
+	}
+	f.handleWriteChunkError(syscall.ENOSPC)
+	if err := f.Wait(); !errors.Is(err, syscall.ENOSPC) {
+		t.Fatalf("Wait error = %v, want ENOSPC", err)
+	}
+}
+
+func TestFetcherSharedTorrentSurfacesWriteErrorToAllSubscribers(t *testing.T) {
+	f1 := buildFetcher().(*Fetcher)
+	f2 := buildFetcher().(*Fetcher)
+	t.Cleanup(func() {
+		_ = f2.Close()
+		_ = f1.Close()
+	})
+
+	request := &base.Request{URL: "./testdata/test.torrent"}
+	if err := f1.Resolve(request, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Resolve(request, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if f1.torrent != f2.torrent {
+		t.Fatal("expected the client to reuse the torrent for the same infohash")
+	}
+	if err := f1.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f2.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	f1.handleWriteChunkError(syscall.ENOSPC)
+	for i, f := range []*Fetcher{f1, f2} {
+		if err := f.Wait(); !errors.Is(err, syscall.ENOSPC) {
+			t.Fatalf("fetcher %d Wait error = %v, want ENOSPC", i+1, err)
+		}
+	}
+}
+
+func TestFetcherIgnoresDelayedErrorFromPreviousGeneration(t *testing.T) {
+	f := buildFetcher().(*Fetcher)
+	t.Cleanup(func() { _ = f.Close() })
+	if err := f.Resolve(&base.Request{URL: "./testdata/test.torrent"}, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Start(); err != nil {
+		t.Fatal(err)
+	}
+	errorOp := f.writeErrorOp
+	errorOp.Lock()
+	oldEpoch := errorOp.epoch
+	errorOp.Unlock()
+	f.handleWriteChunkError(syscall.ENOSPC)
+	if err := f.Wait(); !errors.Is(err, syscall.ENOSPC) {
+		t.Fatalf("first Wait error = %v, want ENOSPC", err)
+	}
+
+	if err := f.Start(); err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- f.Wait() }()
+	dispatchTorrentWriteError(f.torrent, errorOp, oldEpoch, syscall.ENOSPC)
+	select {
+	case err := <-waitCh:
+		t.Fatalf("previous generation error completed the new run: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	f.handleWriteChunkError(syscall.ENOSPC)
+	select {
+	case err := <-waitCh:
+		if !errors.Is(err, syscall.ENOSPC) {
+			t.Fatalf("second Wait error = %v, want ENOSPC", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("current generation write error was not reported")
+	}
+}
+
+func TestFetcherConcurrentSharedResolveAndClose(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		f1 := buildFetcher().(*Fetcher)
+		f2 := buildFetcher().(*Fetcher)
+		request := &base.Request{URL: "./testdata/test.torrent"}
+		if err := f1.Resolve(request, &base.Options{Path: t.TempDir()}); err != nil {
+			t.Fatal(err)
+		}
+		if err := f2.Resolve(request, &base.Options{Path: t.TempDir()}); err != nil {
+			t.Fatal(err)
+		}
+
+		f3 := buildFetcher().(*Fetcher)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if err := f1.Close(); err != nil {
+				t.Errorf("close shared fetcher: %v", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if err := f3.Resolve(request, &base.Options{Path: t.TempDir()}); err != nil {
+				t.Errorf("resolve while shared fetcher closes: %v", err)
+			}
+		}()
+		wg.Wait()
+		if f3.torrent == nil || f3.torrent != f2.torrent {
+			t.Fatal("concurrent close dropped a torrent that still had subscribers")
+		}
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = f2.Close()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = f3.Close()
+		}()
+		wg.Wait()
+	}
+}
+
+func TestFetcherSharedTorrentPreservesTrackersAndMergesSpec(t *testing.T) {
+	f1 := buildFetcher().(*Fetcher)
+	f2 := buildFetcher().(*Fetcher)
+	t.Cleanup(func() {
+		_ = f2.Close()
+		_ = f1.Close()
+	})
+	tracker1 := "http://tracker-one.invalid/announce"
+	tracker2 := "http://tracker-two.invalid/announce"
+	if err := f1.Resolve(&base.Request{
+		URL:   "./testdata/test.torrent",
+		Extra: bt.ReqExtra{Trackers: []string{tracker1}},
+	}, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	magnet := "magnet:?xt=urn:btih:ccbc92b0cd8deec16a2ef4be242a8c9243b1cedb" +
+		"&tr=" + url.QueryEscape(tracker2) +
+		"&ws=" + url.QueryEscape("http://webseed.invalid/files/")
+	if err := f2.Resolve(&base.Request{URL: magnet}, &base.Options{Path: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if f1.torrent != f2.torrent {
+		t.Fatal("expected the same torrent instance")
+	}
+
+	metaInfo := f1.torrent.Metainfo()
+	trackers := strings.Join(metaInfo.UpvertedAnnounceList().DistinctValues(), "\n")
+	if !strings.Contains(trackers, tracker1) {
+		t.Errorf("shared torrent lost its existing tracker %q: %s", tracker1, trackers)
+	}
+	if got := len(f1.torrent.WebseedPeerConns()); got == 0 {
+		t.Fatal("existing torrent did not merge the magnet webseed")
+	}
+}
+
 func TestFetcher_Config(t *testing.T) {
-	doResolve(t, buildConfigFetcher(nil))
+	doResolve(t, func() fetcher.Fetcher { return buildConfigFetcher(nil) })
 }
 
 func TestFetcher_ResolveWithProxy(t *testing.T) {
@@ -61,18 +236,22 @@ func TestFetcher_ResolveWithProxy(t *testing.T) {
 	proxyListener := test.StartSocks5Server(usr, pwd)
 	defer proxyListener.Close()
 
-	doResolve(t, buildConfigFetcher(&base.DownloaderProxyConfig{
-		Enable: true,
-		System: false,
-		Scheme: "socks5",
-		Host:   proxyListener.Addr().String(),
-		Usr:    usr,
-		Pwd:    pwd,
-	}))
+	doResolve(t, func() fetcher.Fetcher {
+		return buildConfigFetcher(&base.DownloaderProxyConfig{
+			Enable: true,
+			System: false,
+			Scheme: "socks5",
+			Host:   proxyListener.Addr().String(),
+			Usr:    usr,
+			Pwd:    pwd,
+		})
+	})
 }
 
-func doResolve(t *testing.T, fetcher fetcher.Fetcher) {
+func doResolve(t *testing.T, build func() fetcher.Fetcher) {
 	t.Run("Resolve Single File", func(t *testing.T) {
+		fetcher := build()
+		t.Cleanup(func() { _ = fetcher.Close() })
 		err := fetcher.Resolve(&base.Request{
 			URL: "./testdata/ubuntu-22.04-live-server-amd64.iso.torrent",
 			Extra: bt.ReqExtra{
@@ -103,6 +282,8 @@ func doResolve(t *testing.T, fetcher fetcher.Fetcher) {
 	})
 
 	t.Run("Resolve Multi Files", func(t *testing.T) {
+		fetcher := build()
+		t.Cleanup(func() { _ = fetcher.Close() })
 		err := fetcher.Resolve(&base.Request{
 			URL: "./testdata/test.torrent",
 			Extra: bt.ReqExtra{
@@ -143,6 +324,8 @@ func doResolve(t *testing.T, fetcher fetcher.Fetcher) {
 	})
 
 	t.Run("Resolve Unclean Torrent", func(t *testing.T) {
+		fetcher := build()
+		t.Cleanup(func() { _ = fetcher.Close() })
 		err := fetcher.Resolve(&base.Request{
 			URL: "./testdata/test.unclean.torrent",
 		}, nil)
@@ -152,6 +335,8 @@ func doResolve(t *testing.T, fetcher fetcher.Fetcher) {
 	})
 
 	t.Run("Resolve file scheme Torrent", func(t *testing.T) {
+		fetcher := build()
+		t.Cleanup(func() { _ = fetcher.Close() })
 		file, _ := filepath.Abs("./testdata/test.unclean.torrent")
 		uri := "file:///" + file
 		err := fetcher.Resolve(&base.Request{
@@ -244,6 +429,7 @@ func buildConfigFetcher(proxyConfig *base.DownloaderProxyConfig) fetcher.Fetcher
 // It tests modifying selected files after Resolve (without downloading).
 func TestFetcher_Patch(t *testing.T) {
 	f := buildFetcher()
+	t.Cleanup(func() { _ = f.Close() })
 
 	// Resolve a multi-file torrent
 	err := f.Resolve(&base.Request{

--- a/internal/protocol/http/fetcher.go
+++ b/internal/protocol/http/fetcher.go
@@ -109,6 +109,99 @@ type connection struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+	run    *downloadRun
+}
+
+type targetFile interface {
+	WriteAt(p []byte, off int64) (n int, err error)
+	Close() error
+}
+
+type targetWriteError struct {
+	err error
+}
+
+// downloadRun owns all lifecycle state for one Start invocation. Keeping these
+// values run-local prevents an immediate retry from replacing channels or
+// cancellation functions that are still used by the previous run.
+type downloadRun struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	loopDone chan struct{}
+
+	terminalErrMu sync.Mutex
+	terminalErr   error
+
+	completionOnce sync.Once
+	resultMu       sync.Mutex
+	resultErr      error
+	resultReady    bool
+}
+
+func newDownloadRun() *downloadRun {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &downloadRun{
+		ctx:      ctx,
+		cancel:   cancel,
+		loopDone: make(chan struct{}),
+	}
+}
+
+func (r *downloadRun) fail(err error) {
+	if err == nil {
+		return
+	}
+	r.terminalErrMu.Lock()
+	if r.terminalErr == nil {
+		r.terminalErr = err
+	}
+	r.terminalErrMu.Unlock()
+	r.cancel()
+}
+
+func (r *downloadRun) getTerminalErr() error {
+	r.terminalErrMu.Lock()
+	defer r.terminalErrMu.Unlock()
+	return r.terminalErr
+}
+
+func (r *downloadRun) setResult(err error) {
+	r.completionOnce.Do(func() {
+		r.resultMu.Lock()
+		r.resultErr = err
+		r.resultReady = true
+		r.resultMu.Unlock()
+	})
+}
+
+func (r *downloadRun) result() (error, bool) {
+	r.resultMu.Lock()
+	defer r.resultMu.Unlock()
+	return r.resultErr, r.resultReady
+}
+
+func (e *targetWriteError) Error() string {
+	return fmt.Sprintf("write http data: %v", e.err)
+}
+
+func (e *targetWriteError) Unwrap() error {
+	return e.err
+}
+
+func isTargetWriteError(err error) bool {
+	var targetErr *targetWriteError
+	return errors.As(err, &targetErr)
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 // ============================================================================
@@ -219,7 +312,8 @@ type Fetcher struct {
 	meta *fetcher.FetcherMeta
 
 	// State machine
-	state atomic.Int32 // fetcherState
+	state  atomic.Int32 // fetcherState
+	closed atomic.Bool
 
 	// Connections
 	connMu      sync.Mutex
@@ -253,20 +347,20 @@ type Fetcher struct {
 	prefetchDone     atomic.Bool   // Prefetch completed or stopped
 	prefetchErr      error         // Error during prefetch (if any)
 	prefetchStopCh   chan struct{} // Signal to stop prefetch
+	prefetchDoneCh   chan struct{} // Closed after asyncPrefetch releases its resources
+	prefetchStopOnce sync.Once
 
 	// Target file
-	file         *os.File
+	file         targetFile
 	fileMu       sync.Mutex
 	redirectURL  string
 	redirectLock sync.Mutex
 
 	// Lifecycle control
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-
-	// downloadLoop lifecycle tracking
-	downloadLoopDone chan struct{} // Closed when downloadLoop exits
+	startMu sync.Mutex
+	runMu   sync.Mutex
+	run     *downloadRun
+	wg      sync.WaitGroup
 
 	// Resolve connection control
 	resolveCtx    context.Context
@@ -302,6 +396,12 @@ func (f *Fetcher) getState() fetcherState {
 
 func (f *Fetcher) setState(s fetcherState) {
 	f.state.Store(int32(s))
+}
+
+func (f *Fetcher) currentRun() *downloadRun {
+	f.runMu.Lock()
+	defer f.runMu.Unlock()
+	return f.run
 }
 
 // updateMaxConnTime updates maxConnTime if the new duration is larger
@@ -440,6 +540,9 @@ func (f *Fetcher) Resolve(req *base.Request, opts *base.Options) error {
 	// For non-range resources, the response will be used directly in Start
 	if res.Range && res.Size > 0 {
 		f.prefetchStopCh = make(chan struct{})
+		f.prefetchDoneCh = make(chan struct{})
+		f.prefetchStopOnce = sync.Once{}
+		f.prefetchDone.Store(false)
 		go f.asyncPrefetch()
 	}
 
@@ -456,6 +559,7 @@ func (f *Fetcher) Resolve(req *base.Request, opts *base.Options) error {
 func (f *Fetcher) asyncPrefetch() {
 	defer func() {
 		f.prefetchDone.Store(true)
+		close(f.prefetchDoneCh)
 	}()
 
 	// Get the resolve response
@@ -487,7 +591,6 @@ func (f *Fetcher) asyncPrefetch() {
 	}()
 
 	buf := make([]byte, 32*1024) // 32KB buffer
-	reader := NewTimeoutReader(resp.Body, readTimeout)
 
 	for {
 		select {
@@ -497,7 +600,7 @@ func (f *Fetcher) asyncPrefetch() {
 		default:
 		}
 
-		n, err := reader.Read(buf)
+		n, err := resp.Body.Read(buf)
 		if n > 0 {
 			_, writeErr := tmpFile.Write(buf[:n])
 			if writeErr != nil {
@@ -517,52 +620,117 @@ func (f *Fetcher) asyncPrefetch() {
 	}
 }
 
-// stopPrefetchAndGetData stops the async prefetch and returns prefetched bytes
-// It also copies prefetched data to the target file
-func (f *Fetcher) stopPrefetchAndCopyData() int64 {
-	// Signal prefetch to stop (safely)
-	if f.prefetchStopCh != nil {
-		select {
-		case <-f.prefetchStopCh:
-			// Already closed
-		default:
-			close(f.prefetchStopCh)
-		}
+// stopPrefetch closes the response body to unblock any in-flight read, then
+// waits until asyncPrefetch has stopped using the temporary file.
+func (f *Fetcher) stopPrefetch() {
+	if f.prefetchStopCh == nil {
+		return
 	}
+	f.prefetchStopOnce.Do(func() {
+		close(f.prefetchStopCh)
+	})
 
-	// Wait for prefetch to finish (with timeout)
-	for i := 0; i < 1000 && !f.prefetchDone.Load(); i++ {
-		time.Sleep(10 * time.Millisecond)
+	f.resolveRespLock.Lock()
+	if f.resolveResp != nil {
+		_ = f.resolveResp.Body.Close()
+		f.resolveResp = nil
 	}
+	f.resolveRespLock.Unlock()
+
+	if f.prefetchDoneCh != nil {
+		<-f.prefetchDoneCh
+	}
+}
+
+// stopPrefetchAndCopyData stops async prefetch and copies the available bytes
+// to the target file.
+func (f *Fetcher) stopPrefetchAndCopyData() (copied int64, err error) {
+	f.stopPrefetch()
 
 	prefetched := f.prefetchSize.Load()
 	if prefetched == 0 {
 		f.cleanupPrefetchFile()
-		return 0
+		return 0, nil
 	}
+	defer f.cleanupPrefetchFile()
 
 	// Copy prefetch data to target file
 	if f.prefetchFile != nil && f.file != nil {
 		// Seek to beginning of prefetch file
-		f.prefetchFile.Seek(0, io.SeekStart)
+		if _, err = f.prefetchFile.Seek(0, io.SeekStart); err != nil {
+			return 0, fmt.Errorf("seek http prefetch data: %w", err)
+		}
 
 		// Copy to target file at position 0
 		buf := make([]byte, 32*1024)
-		var copied int64
 		for copied < prefetched {
-			n, err := f.prefetchFile.Read(buf)
+			readBuf := buf
+			if remain := prefetched - copied; remain < int64(len(readBuf)) {
+				readBuf = readBuf[:remain]
+			}
+			n, readErr := f.prefetchFile.Read(readBuf)
 			if n > 0 {
-				f.file.WriteAt(buf[:n], copied)
+				if err = f.writeTargetAt(buf[:n], copied); err != nil {
+					return copied, err
+				}
 				copied += int64(n)
 			}
-			if err != nil {
-				break
+			if readErr != nil {
+				if readErr == io.EOF && copied == prefetched {
+					break
+				}
+				if readErr == io.EOF {
+					readErr = io.ErrUnexpectedEOF
+				}
+				return copied, fmt.Errorf("read http prefetch data: %w", readErr)
 			}
 		}
 	}
 
-	f.cleanupPrefetchFile()
-	return prefetched
+	return copied, nil
+}
+
+func (f *Fetcher) writeTargetAt(p []byte, offset int64) error {
+	f.fileMu.Lock()
+	defer f.fileMu.Unlock()
+
+	if f.file == nil {
+		return &targetWriteError{err: errors.New("target file is unavailable")}
+	}
+	written, err := f.file.WriteAt(p, offset)
+	if err != nil {
+		return &targetWriteError{err: err}
+	}
+	if written != len(p) {
+		return &targetWriteError{err: io.ErrShortWrite}
+	}
+	return nil
+}
+
+func (f *Fetcher) closeTargetFile() error {
+	f.fileMu.Lock()
+	defer f.fileMu.Unlock()
+
+	if f.file == nil {
+		return nil
+	}
+	err := f.file.Close()
+	f.file = nil
+	return err
+}
+
+func (f *Fetcher) markConnectionWriteFailed(conn *connection, err error) {
+	f.connMu.Lock()
+	conn.State = connFailed
+	conn.failed = true
+	conn.lastErr = err
+	f.connMu.Unlock()
+	if f.slowStart != nil {
+		f.slowStart.onConnectFailed()
+	}
+	if conn.run != nil {
+		conn.run.fail(err)
+	}
 }
 
 // cleanupPrefetchFile closes and removes the prefetch temporary file
@@ -578,6 +746,9 @@ func (f *Fetcher) cleanupPrefetchFile() {
 }
 
 func (f *Fetcher) Start() error {
+	if f.closed.Load() {
+		return errors.New("http fetcher is closed")
+	}
 	state := f.getState()
 
 	switch state {
@@ -591,8 +762,9 @@ func (f *Fetcher) Start() error {
 		return nil
 
 	case stateSlowStart, stateSteady:
-		// Already downloading, this is a resume from pause
-		return f.doStart()
+		// Already downloading. Pause transitions to statePaused before returning,
+		// so starting another run here would race the active WaitGroup and file.
+		return nil
 
 	case stateError:
 		// Retry after error: reset and restart
@@ -604,16 +776,28 @@ func (f *Fetcher) Start() error {
 }
 
 func (f *Fetcher) doStart() error {
+	f.startMu.Lock()
+	defer f.startMu.Unlock()
+	if f.closed.Load() {
+		return errors.New("http fetcher is closed")
+	}
+
 	// Wait for resolve to complete
 	<-f.resolvedCh
 
 	state := f.getState()
-	if state == stateDone {
+	if state == stateDone || state == stateSlowStart || state == stateSteady {
 		return nil
 	}
 
 	// If retrying after error, reset connection states for retry
 	if state == stateError {
+		// finishDownload sets stateError before downloadLoop publishes the result.
+		// A caller may retry based on state without first calling Wait, so ensure
+		// the old run has completely exited before replacing run-local state.
+		if previousRun := f.currentRun(); previousRun != nil {
+			<-previousRun.loopDone
+		}
 		// Drain any pending error from doneCh before retry
 		select {
 		case <-f.doneCh:
@@ -660,8 +844,8 @@ func (f *Fetcher) doStart() error {
 	var prefetchedBytes int64
 	if f.meta.Res.Range {
 		// Stop async prefetch and copy data to target file
-		prefetchedBytes = f.stopPrefetchAndCopyData()
-		f.resolveDataPos.Store(prefetchedBytes)
+		var copyErr error
+		prefetchedBytes, copyErr = f.stopPrefetchAndCopyData()
 
 		// Also close resolve response if still open
 		f.resolveRespLock.Lock()
@@ -670,10 +854,16 @@ func (f *Fetcher) doStart() error {
 			f.resolveResp = nil
 		}
 		f.resolveRespLock.Unlock()
+		if copyErr != nil {
+			_ = f.closeTargetFile()
+			return copyErr
+		}
+		f.resolveDataPos.Store(prefetchedBytes)
 	}
 
 	// Avoid request extra modified by extension
 	if err = base.ParseReqExtra[fhttp.ReqExtra](f.meta.Req); err != nil {
+		_ = f.closeTargetFile()
 		return err
 	}
 
@@ -681,71 +871,86 @@ func (f *Fetcher) doStart() error {
 	maxConns := f.meta.Opts.Extra.(*fhttp.OptsExtra).Connections
 	f.slowStart = newSlowStartController(maxConns)
 
-	// Create main context
-	f.ctx, f.cancel = context.WithCancel(context.Background())
-
-	// Create downloadLoop lifecycle channel
-	f.downloadLoopDone = make(chan struct{})
+	// Create run-local lifecycle state. Wait is signalled only after this run's
+	// loop and all of its connection goroutines have exited.
+	run := newDownloadRun()
+	f.runMu.Lock()
+	f.run = run
+	f.runMu.Unlock()
 
 	// Start download
 	f.setState(stateSlowStart)
-	go f.downloadLoop()
+	go f.downloadLoop(run)
 
 	return nil
 }
 
-func (f *Fetcher) downloadLoop() {
+func (f *Fetcher) downloadLoop(run *downloadRun) {
 	defer func() {
 		// Update file last modified time before closing
 		if f.config.UseServerCtime && f.meta.Res.Files[0].Ctime != nil {
 			setft.SetFileTime(f.meta.SingleFilepath(), time.Now(), *f.meta.Res.Files[0].Ctime, *f.meta.Res.Files[0].Ctime)
 		}
 
-		// Signal that downloadLoop has exited
-		if f.downloadLoopDone != nil {
-			close(f.downloadLoopDone)
+		if err, ok := run.result(); ok {
+			f.doneCh <- err
 		}
+		// Close only after the result has been published. A retry waiting on
+		// loopDone can now safely drain the previous result before replacing run.
+		close(run.loopDone)
 	}()
 
 	// Check if this is a resume or fresh start
+	f.connMu.Lock()
 	isResume := len(f.connections) > 0
+	f.connMu.Unlock()
 
 	if !isResume {
 		// Fresh start: begin with resolve connection
-		f.startResolveDownload()
+		f.startResolveDownload(run)
+		if _, completed := run.result(); completed {
+			return
+		}
+		if !f.meta.Res.Range || f.meta.Res.Size == 0 {
+			return
+		}
 	} else {
 		// Resume: restart existing connections
-		f.resumeConnections()
-		f.waitForCompletion()
+		f.resumeConnections(run)
+		f.waitForCompletion(run)
 		return
 	}
 
 	// Slow start loop
 	for {
 		select {
-		case <-f.ctx.Done():
-			// Paused or cancelled
+		case <-run.ctx.Done():
+			// A target write error is terminal for the whole run. Pause also
+			// cancels the context, but intentionally has no completion result.
+			if run.getTerminalErr() != nil {
+				f.waitForCompletion(run)
+			}
 			return
 		case <-f.slowStart.expansionCh:
 			// Batch completed, try to expand
 			if f.checkCompletion() {
 				// All work is done, wait for connections to finish
-				f.waitForCompletion()
+				f.waitForCompletion(run)
 				return
 			}
-			f.expandConnections()
+			f.expandConnections(run)
 
 			// Check if we've reached steady state (max connections)
 			if f.getState() == stateSteady {
 				// Wait for all connections to complete
-				f.waitForCompletion()
+				f.waitForCompletion(run)
 				return
 			}
 		}
 	}
 }
 
-func (f *Fetcher) startResolveDownload() {
+func (f *Fetcher) startResolveDownload(run *downloadRun) {
 	// If no range support or size unknown, just use single connection with resolve response
 	if !f.meta.Res.Range || f.meta.Res.Size == 0 {
 		// Create a single connection for the entire file
@@ -755,8 +960,11 @@ func (f *Fetcher) startResolveDownload() {
 			State: connNotStarted,
 			Chunk: newChunk(0, 0), // For non-range, end doesn't matter
 		}
-		conn.ctx, conn.cancel = context.WithCancel(f.ctx)
+		conn.ctx, conn.cancel = context.WithCancel(run.ctx)
+		conn.run = run
+		f.connMu.Lock()
 		f.connections = append(f.connections, conn)
+		f.connMu.Unlock()
 
 		f.wg.Add(1)
 		// Use the resolve response directly
@@ -764,16 +972,16 @@ func (f *Fetcher) startResolveDownload() {
 
 		// For non-range downloads, wait for completion directly in this goroutine
 		// Don't create another goroutine to avoid WaitGroup reuse issues
-		f.waitForCompletion()
+		f.waitForCompletion(run)
 		return
 	}
 
 	// Range supported: use slow start to launch connections
 	// Start first batch of connections
-	f.expandConnections()
+	f.expandConnections(run)
 }
 
-func (f *Fetcher) expandConnections() {
+func (f *Fetcher) expandConnections(run *downloadRun) {
 	batchSize := f.slowStart.getNextBatchSize()
 	if batchSize <= 0 {
 		// Max reached, transition to steady state
@@ -795,17 +1003,7 @@ func (f *Fetcher) expandConnections() {
 		// If prefetched all data, mark as done
 		if prefetched >= totalSize {
 			f.connMu.Unlock()
-
-			// Close the file before signaling completion
-			f.fileMu.Lock()
-			if f.file != nil {
-				f.file.Close()
-				f.file = nil
-			}
-			f.fileMu.Unlock()
-
-			f.setState(stateDone)
-			f.doneCh <- nil
+			f.finishDownload(run, nil)
 			return
 		}
 
@@ -820,7 +1018,8 @@ func (f *Fetcher) expandConnections() {
 		conn.Chunk.Downloaded = 0    // Start fresh from prefetched position
 		conn.Downloaded = prefetched // Track total downloaded including prefetch
 
-		conn.ctx, conn.cancel = context.WithCancel(f.ctx)
+		conn.ctx, conn.cancel = context.WithCancel(run.ctx)
+		conn.run = run
 		f.connections = append(f.connections, conn)
 		f.connMu.Unlock()
 
@@ -870,7 +1069,8 @@ func (f *Fetcher) expandConnections() {
 			State: connNotStarted,
 			Chunk: newChunk,
 		}
-		conn.ctx, conn.cancel = context.WithCancel(f.ctx)
+		conn.ctx, conn.cancel = context.WithCancel(run.ctx)
+		conn.run = run
 
 		newConns = append(newConns, conn)
 		f.connections = append(f.connections, conn)
@@ -881,7 +1081,6 @@ func (f *Fetcher) expandConnections() {
 	if len(newConns) == 0 {
 		// No new connections could be created, stop expansion
 		f.setState(stateSteady)
-		go f.waitForCompletion()
 		return
 	}
 
@@ -900,6 +1099,7 @@ func (f *Fetcher) runConnection(conn *connection) {
 
 	f.connMu.Lock()
 	conn.State = connConnecting
+	conn.retryTimes = 0
 	f.connMu.Unlock()
 
 	// Use fast-fail client for quick retry during download phase
@@ -907,7 +1107,6 @@ func (f *Fetcher) runConnection(conn *connection) {
 	buf := make([]byte, 8192)
 
 	retries := 0
-	conn.retryTimes = 0
 
 	for {
 		// Rebuild client with updated fast-fail timeout on retries
@@ -927,19 +1126,27 @@ func (f *Fetcher) runConnection(conn *connection) {
 
 			// Reset counters after a successful help switch
 			retries = 0
+			f.connMu.Lock()
 			conn.retryTimes = 0
+			f.connMu.Unlock()
 			continue
 		}
 
 		if errors.Is(err, context.Canceled) {
 			return
 		}
+		if isTargetWriteError(err) {
+			f.markConnectionWriteFailed(conn, err)
+			return
+		}
 
+		f.connMu.Lock()
 		if re := extractRequestError(err); re != nil {
 			conn.lastErr = re
 		} else {
 			conn.lastErr = err
 		}
+		f.connMu.Unlock()
 
 		if shouldCountHTTPFailure(err) {
 			if re := extractRequestError(err); re != nil && re.Code == 403 {
@@ -952,14 +1159,15 @@ func (f *Fetcher) runConnection(conn *connection) {
 				}
 				return
 			}
-			conn.retryTimes++
 			f.connMu.Lock()
+			conn.retryTimes++
+			retryTimes := conn.retryTimes
 			conn.failed = true
 			f.connMu.Unlock()
 			if f.slowStart != nil {
 				f.slowStart.onConnectFailed()
 			}
-			if conn.retryTimes >= 3 {
+			if retryTimes >= 3 {
 				f.connMu.Lock()
 				conn.State = connFailed
 				f.connMu.Unlock()
@@ -975,7 +1183,9 @@ func (f *Fetcher) runConnection(conn *connection) {
 			retryDelay = 5 * time.Second
 		}
 		retries++
-		time.Sleep(retryDelay)
+		if !waitForRetry(conn.ctx, retryDelay) {
+			return
+		}
 	}
 }
 
@@ -1091,15 +1301,9 @@ func (f *Fetcher) downloadChunkOnce(conn *connection, client *http.Client, buf [
 			writeOffset = conn.Chunk.Begin + conn.Chunk.Downloaded
 			f.connMu.Unlock()
 
-			f.fileMu.Lock()
-			if f.file != nil {
-				_, writeErr := f.file.WriteAt(buf[:n], writeOffset)
-				if writeErr != nil {
-					f.fileMu.Unlock()
-					return writeErr
-				}
+			if writeErr := f.writeTargetAt(buf[:n], writeOffset); writeErr != nil {
+				return writeErr
 			}
-			f.fileMu.Unlock()
 
 			// Lock again to update Downloaded atomically with the read above
 			f.connMu.Lock()
@@ -1181,25 +1385,18 @@ func (f *Fetcher) runConnectionWithResolveResp(conn *connection) {
 
 		n, err := reader.Read(buf)
 		if n > 0 {
-			f.fileMu.Lock()
-			if f.file != nil {
-				_, writeErr := f.file.WriteAt(buf[:n], conn.Chunk.Downloaded)
-				if writeErr != nil {
-					f.fileMu.Unlock()
-					f.connMu.Lock()
-					conn.State = connFailed
-					conn.failed = true
-					f.connMu.Unlock()
-					if f.slowStart != nil {
-						f.slowStart.onConnectFailed()
-					}
-					return
-				}
+			f.connMu.Lock()
+			writeOffset := conn.Chunk.Downloaded
+			f.connMu.Unlock()
+			if writeErr := f.writeTargetAt(buf[:n], writeOffset); writeErr != nil {
+				f.markConnectionWriteFailed(conn, writeErr)
+				return
 			}
-			f.fileMu.Unlock()
 
+			f.connMu.Lock()
 			conn.Chunk.Downloaded += int64(n)
 			conn.Downloaded += int64(n)
+			f.connMu.Unlock()
 		}
 		if err != nil {
 			if err == io.EOF {
@@ -1283,18 +1480,17 @@ func (f *Fetcher) runConnectionFallback(conn *connection) {
 
 				n, err := reader.Read(buf)
 				if n > 0 {
-					f.fileMu.Lock()
-					if f.file != nil {
-						_, writeErr := f.file.WriteAt(buf[:n], conn.Chunk.Downloaded)
-						if writeErr != nil {
-							f.fileMu.Unlock()
-							return writeErr
-						}
+					f.connMu.Lock()
+					writeOffset := conn.Chunk.Downloaded
+					f.connMu.Unlock()
+					if writeErr := f.writeTargetAt(buf[:n], writeOffset); writeErr != nil {
+						return writeErr
 					}
-					f.fileMu.Unlock()
 
+					f.connMu.Lock()
 					conn.Chunk.Downloaded += int64(n)
 					conn.Downloaded += int64(n)
+					f.connMu.Unlock()
 				}
 				if err != nil {
 					if err == io.EOF {
@@ -1316,12 +1512,18 @@ func (f *Fetcher) runConnectionFallback(conn *connection) {
 		if errors.Is(err, context.Canceled) {
 			return
 		}
+		if isTargetWriteError(err) {
+			f.markConnectionWriteFailed(conn, err)
+			return
+		}
 
+		f.connMu.Lock()
 		if re := extractRequestError(err); re != nil {
 			conn.lastErr = re
 		} else {
 			conn.lastErr = err
 		}
+		f.connMu.Unlock()
 
 		if shouldCountHTTPFailure(err) {
 			// Immediate fail for server connection limit (403)
@@ -1335,7 +1537,9 @@ func (f *Fetcher) runConnectionFallback(conn *connection) {
 				}
 				return
 			}
+			f.connMu.Lock()
 			conn.retryTimes++
+			f.connMu.Unlock()
 			countedRetries++
 			if countedRetries >= 3 {
 				f.connMu.Lock()
@@ -1356,7 +1560,9 @@ func (f *Fetcher) runConnectionFallback(conn *connection) {
 				retryDelay = 5 * time.Second
 			}
 			retries++
-			time.Sleep(retryDelay)
+			if !waitForRetry(conn.ctx, retryDelay) {
+				return
+			}
 			continue
 		}
 
@@ -1369,7 +1575,9 @@ func (f *Fetcher) runConnectionFallback(conn *connection) {
 			retryDelay = 5 * time.Second
 		}
 		retries++
-		time.Sleep(retryDelay)
+		if !waitForRetry(conn.ctx, retryDelay) {
+			return
+		}
 	}
 }
 
@@ -1441,7 +1649,7 @@ func (f *Fetcher) resetConnectionForRestart(conn *connection) {
 	conn.lastSpeedDownload = 0
 }
 
-func (f *Fetcher) resumeConnections() {
+func (f *Fetcher) resumeConnections(run *downloadRun) {
 	// Collect connections to resume while holding the lock
 	var toResume []*connection
 
@@ -1466,7 +1674,8 @@ func (f *Fetcher) resumeConnections() {
 		}
 		f.resetConnectionForRestart(conn)
 		// Reset the connection state for resume
-		conn.ctx, conn.cancel = context.WithCancel(f.ctx)
+		conn.ctx, conn.cancel = context.WithCancel(run.ctx)
+		conn.run = run
 		conn.State = connNotStarted
 		conn.failed = false // Clear failed flag for resumed connection
 		toResume = append(toResume, conn)
@@ -1480,15 +1689,16 @@ func (f *Fetcher) resumeConnections() {
 	}
 }
 
-func (f *Fetcher) waitForCompletion() {
+func (f *Fetcher) waitForCompletion(run *downloadRun) {
 	f.wg.Wait()
-	// Only trigger completion if not cancelled/paused
-	if f.ctx != nil && f.ctx.Err() == nil {
-		f.onDownloadComplete()
+	// Target write errors cancel sibling connections but must still complete the
+	// run with the original local-storage error. A plain cancellation is Pause.
+	if run.getTerminalErr() != nil || run.ctx.Err() == nil {
+		f.onDownloadComplete(run)
 	}
 }
 
-func (f *Fetcher) onDownloadComplete() {
+func (f *Fetcher) onDownloadComplete(run *downloadRun) {
 	f.connMu.Lock()
 
 	// First, check if download actually completed successfully
@@ -1531,8 +1741,8 @@ func (f *Fetcher) onDownloadComplete() {
 	downloadComplete := f.meta.Res.Size > 0 && totalDownloaded >= f.meta.Res.Size
 
 	// Check for any errors, but ignore 403 (server connection limit) errors if download completed
-	var finalErr error
-	if !downloadComplete && !allChunksComplete {
+	finalErr := run.getTerminalErr()
+	if finalErr == nil && !downloadComplete && !allChunksComplete {
 		for _, conn := range f.connections {
 			if conn.State == connFailed && conn.failed {
 				// Skip 403 errors (server connection limit) - these are expected when exceeding server's limit
@@ -1541,6 +1751,8 @@ func (f *Fetcher) onDownloadComplete() {
 				}
 				if re := extractRequestError(conn.lastErr); re != nil {
 					finalErr = fmt.Errorf("connection %d failed: retries=%d, status=%d", conn.ID, conn.retryTimes, re.Code)
+				} else if isTargetWriteError(conn.lastErr) {
+					finalErr = conn.lastErr
 				} else if conn.lastErr != nil {
 					finalErr = fmt.Errorf("connection %d failed: retries=%d, err=%v", conn.ID, conn.retryTimes, conn.lastErr)
 				} else {
@@ -1552,14 +1764,15 @@ func (f *Fetcher) onDownloadComplete() {
 	}
 	f.connMu.Unlock()
 
-	// Close the file before signaling completion
-	// This ensures the file handle is released before Wait() returns
-	f.fileMu.Lock()
-	if f.file != nil {
-		f.file.Close()
-		f.file = nil
+	f.finishDownload(run, finalErr)
+}
+
+// finishDownload closes the target and records exactly one terminal result.
+// downloadLoop publishes that result only after its defer closes loopDone.
+func (f *Fetcher) finishDownload(run *downloadRun, finalErr error) {
+	if closeErr := f.closeTargetFile(); closeErr != nil && finalErr == nil {
+		finalErr = fmt.Errorf("close http target file: %w", closeErr)
 	}
-	f.fileMu.Unlock()
 
 	if finalErr != nil {
 		f.setState(stateError)
@@ -1567,10 +1780,7 @@ func (f *Fetcher) onDownloadComplete() {
 		f.setState(stateDone)
 	}
 
-	select {
-	case f.doneCh <- finalErr:
-	default:
-	}
+	run.setResult(finalErr)
 }
 
 func (f *Fetcher) checkCompletion() bool {
@@ -1666,35 +1876,31 @@ func (f *Fetcher) Patch(req *base.Request, opts *base.Options) error {
 }
 
 func (f *Fetcher) Pause() error {
-	if f.cancel != nil {
-		f.cancel()
+	f.startMu.Lock()
+	defer f.startMu.Unlock()
+	return f.pauseLocked()
+}
+
+func (f *Fetcher) pauseLocked() error {
+	run := f.currentRun()
+	if run != nil {
+		run.cancel()
 	}
 	if f.resolveCancel != nil {
 		f.resolveCancel()
 	}
 
-	// Stop prefetch if running
-	if f.prefetchStopCh != nil {
-		select {
-		case <-f.prefetchStopCh:
-			// Already closed
-		default:
-			close(f.prefetchStopCh)
-		}
-	}
+	// Closing the resolve body unblocks prefetch before its temporary file is
+	// sought, copied, closed, or removed.
+	f.stopPrefetch()
 
-	// Wait for downloadLoop to exit first (it will call wg.Wait internally)
-	if f.downloadLoopDone != nil {
-		<-f.downloadLoopDone
+	// Wait for this exact run rather than a channel that a retry can replace.
+	if run != nil {
+		<-run.loopDone
 	}
 
 	// Wait for all connection goroutines to stop
 	f.wg.Wait()
-
-	// Wait for prefetch to finish
-	for f.prefetchStopCh != nil && !f.prefetchDone.Load() {
-		time.Sleep(10 * time.Millisecond)
-	}
 
 	// Clean up prefetch file
 	f.cleanupPrefetchFile()
@@ -1707,19 +1913,17 @@ func (f *Fetcher) Pause() error {
 	}
 	f.resolveRespLock.Unlock()
 
-	f.fileMu.Lock()
-	if f.file != nil {
-		f.file.Close()
-		f.file = nil
-	}
-	f.fileMu.Unlock()
+	_ = f.closeTargetFile()
 
 	f.setState(statePaused)
 	return nil
 }
 
 func (f *Fetcher) Close() error {
-	err := f.Pause()
+	f.startMu.Lock()
+	defer f.startMu.Unlock()
+	f.closed.Store(true)
+	err := f.pauseLocked()
 	if f.impersonationSession != nil {
 		f.impersonationSession.Clear()
 	}
@@ -1752,11 +1956,10 @@ func (f *Fetcher) Progress() fetcher.Progress {
 	p := make(fetcher.Progress, 0)
 
 	total := int64(0)
+	f.connMu.Lock()
 	if f.resolveConn != nil {
 		total += f.resolveConn.Downloaded
 	}
-
-	f.connMu.Lock()
 	for _, conn := range f.connections {
 		total += conn.Downloaded
 	}

--- a/internal/protocol/http/fetcher_manager.go
+++ b/internal/protocol/http/fetcher_manager.go
@@ -72,11 +72,22 @@ func (fm *FetcherManager) DefaultConfig() any {
 
 func (fm *FetcherManager) Store(f fetcher.Fetcher) (data any, err error) {
 	_f := f.(*Fetcher)
+	_f.connMu.Lock()
+	connections := make([]*connection, 0, len(_f.connections))
+	for _, conn := range _f.connections {
+		connCopy := *conn
+		if conn.Chunk != nil {
+			chunkCopy := *conn.Chunk
+			connCopy.Chunk = &chunkCopy
+		}
+		connections = append(connections, &connCopy)
+	}
+	_f.connMu.Unlock()
 	_f.redirectLock.Lock()
 	redirectURL := _f.redirectURL
 	_f.redirectLock.Unlock()
 	return &fetcherData{
-		Connections: _f.connections,
+		Connections: connections,
 		RedirectURL: redirectURL,
 	}, nil
 }

--- a/internal/protocol/http/fetcher_test.go
+++ b/internal/protocol/http/fetcher_test.go
@@ -2,14 +2,18 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	gohttp "net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -20,6 +24,47 @@ import (
 	"github.com/GopeedLab/gopeed/pkg/base"
 	"github.com/GopeedLab/gopeed/pkg/protocol/http"
 )
+
+type failingTargetFile struct {
+	err    error
+	writes atomic.Int32
+	closed atomic.Bool
+}
+
+type blockingResponseBody struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	readOnce    sync.Once
+	closeOnce   sync.Once
+}
+
+func newBlockingResponseBody() *blockingResponseBody {
+	return &blockingResponseBody{
+		readStarted: make(chan struct{}),
+		closed:      make(chan struct{}),
+	}
+}
+
+func (b *blockingResponseBody) Read([]byte) (int, error) {
+	b.readOnce.Do(func() { close(b.readStarted) })
+	<-b.closed
+	return 0, gohttp.ErrServerClosed
+}
+
+func (b *blockingResponseBody) Close() error {
+	b.closeOnce.Do(func() { close(b.closed) })
+	return nil
+}
+
+func (f *failingTargetFile) WriteAt([]byte, int64) (int, error) {
+	f.writes.Add(1)
+	return 0, f.err
+}
+
+func (f *failingTargetFile) Close() error {
+	f.closed.Store(true)
+	return nil
+}
 
 func TestFetcher_Resolve(t *testing.T) {
 	testResolve(test.StartTestFileServer, test.BuildName, t, func(err error) (*base.Resource, error) {
@@ -221,7 +266,7 @@ func TestFetcher_ResolveWithHostHeader(t *testing.T) {
 	listener := test.StartTestHostHeaderServer()
 	defer listener.Close()
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/",
 		Extra: &http.ReqExtra{
@@ -243,7 +288,7 @@ func TestFetcher_ResolveWithInvalidHeader(t *testing.T) {
 	listener := test.StartTestCustomServer()
 	defer listener.Close()
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	defer fetcher.Pause() // Close the resolve response to allow server shutdown
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/",
@@ -272,7 +317,7 @@ func TestFetcher_ResolveAutomaticallyFallsBackToBrowserFingerprint(t *testing.T)
 		}),
 	})
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	defer fetcher.Pause()
 	err := fetcher.Resolve(&base.Request{
 		URL:            server.URL + "/file.bin",
@@ -304,7 +349,7 @@ func TestFetcherSharesAndClearsImpersonationSession(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	fetcher.meta.Req = &base.Request{URL: server.URL}
 
 	for range 2 {
@@ -338,7 +383,7 @@ func TestFetcherSharesAndClearsImpersonationSession(t *testing.T) {
 func testResolve(startTestServer func() net.Listener, path string, t *testing.T, wantFn func(error) (*base.Resource, error)) {
 	listener := startTestServer()
 	defer listener.Close()
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	defer fetcher.Pause() // Close the resolve response to allow server shutdown
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/" + path,
@@ -637,7 +682,7 @@ func TestFetcher_DownloadOneTimeURL(t *testing.T) {
 	listener := test.StartTestOneTimeServer()
 	defer listener.Close()
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 	}, &base.Options{
@@ -766,7 +811,7 @@ func TestFetcher_AsyncPrefetch(t *testing.T) {
 		listener := test.StartTestFileServer()
 		defer listener.Close()
 
-		fetcher := buildFetcher()
+		fetcher := buildFetcher(t)
 		err := fetcher.Resolve(&base.Request{
 			URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 		}, &base.Options{
@@ -837,7 +882,7 @@ func TestFetcher_AsyncPrefetch(t *testing.T) {
 		listener := test.StartTestLowSpeedServer(100 * time.Nanosecond)
 		defer listener.Close()
 
-		fetcher := buildFetcher()
+		fetcher := buildFetcher(t)
 		err := fetcher.Resolve(&base.Request{
 			URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 		}, &base.Options{
@@ -901,6 +946,292 @@ func TestFetcher_AsyncPrefetch(t *testing.T) {
 	})
 }
 
+func TestFetcher_RangeWriteErrorStopsWithoutRetry(t *testing.T) {
+	payload := []byte("range response")
+	var requests atomic.Int32
+	server := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		requests.Add(1)
+		w.WriteHeader(gohttp.StatusPartialContent)
+		_, _ = w.Write(payload)
+	}))
+	defer server.Close()
+
+	f := buildFetcher(t)
+	target := &failingTargetFile{err: syscall.ENOSPC}
+	f.file = target
+	f.meta = &fetcher.FetcherMeta{
+		Req: &base.Request{URL: server.URL},
+		Res: &base.Resource{Range: true, Size: int64(len(payload))},
+	}
+	f.slowStart = newSlowStartController(1)
+	startTestDownloadLoop(f)
+
+	assertFetcherWriteError(t, f, target)
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1 (write errors must not be retried)", got)
+	}
+}
+
+func TestFetcher_NonRangeWriteError(t *testing.T) {
+	payload := []byte("non-range response")
+
+	t.Run("resolve response", func(t *testing.T) {
+		f := buildFetcher(t)
+		target := &failingTargetFile{err: syscall.ENOSPC}
+		f.file = target
+		f.meta = &fetcher.FetcherMeta{
+			Req: &base.Request{URL: "https://example.com/file"},
+			Res: &base.Resource{Size: int64(len(payload))},
+		}
+		f.slowStart = newSlowStartController(1)
+		f.resolveResp = &gohttp.Response{Body: io.NopCloser(strings.NewReader(string(payload)))}
+		startTestDownloadLoop(f)
+
+		assertFetcherWriteError(t, f, target)
+	})
+
+	t.Run("fallback response", func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+			requests.Add(1)
+			_, _ = w.Write(payload)
+		}))
+		defer server.Close()
+
+		f := buildFetcher(t)
+		target := &failingTargetFile{err: syscall.ENOSPC}
+		f.file = target
+		f.meta = &fetcher.FetcherMeta{
+			Req: &base.Request{URL: server.URL},
+			Res: &base.Resource{Size: int64(len(payload))},
+		}
+		f.slowStart = newSlowStartController(1)
+		startTestDownloadLoop(f)
+
+		assertFetcherWriteError(t, f, target)
+		if got := requests.Load(); got != 1 {
+			t.Fatalf("request count = %d, want 1 (write errors must not be retried)", got)
+		}
+	})
+}
+
+func TestFetcher_WriteErrorCancelsSiblingConnections(t *testing.T) {
+	payload := []byte("x")
+	stalledStarted := make(chan struct{})
+	stalledCanceled := make(chan struct{})
+	var stalledStartOnce sync.Once
+	var stalledCancelOnce sync.Once
+	server := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		if r.Header.Get("Range") == "bytes=0-0" {
+			select {
+			case <-stalledStarted:
+			case <-r.Context().Done():
+				return
+			}
+			w.Header().Set("Content-Range", "bytes 0-0/2")
+			w.WriteHeader(gohttp.StatusPartialContent)
+			_, _ = w.Write(payload)
+			return
+		}
+		stalledStartOnce.Do(func() { close(stalledStarted) })
+		<-r.Context().Done()
+		stalledCancelOnce.Do(func() { close(stalledCanceled) })
+	}))
+	defer server.Close()
+
+	f := buildFetcher(t)
+	target := &failingTargetFile{err: syscall.ENOSPC}
+	f.file = target
+	f.meta = &fetcher.FetcherMeta{
+		Req: &base.Request{URL: server.URL},
+		Res: &base.Resource{Range: true, Size: 2},
+	}
+	f.connections = []*connection{
+		{ID: 0, Role: rolePrimary, State: connNotStarted, Chunk: newChunk(0, 0)},
+		{ID: 1, Role: roleWorker, State: connNotStarted, Chunk: newChunk(1, 1)},
+	}
+	startTestDownloadLoop(f)
+
+	select {
+	case <-stalledStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sibling request did not start")
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- f.Wait() }()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, syscall.ENOSPC) {
+			t.Fatalf("Wait error = %v, want ENOSPC", err)
+		}
+	case <-time.After(2 * time.Second):
+		f.currentRun().cancel()
+		t.Fatal("write error did not cancel the stalled sibling")
+	}
+	select {
+	case <-stalledCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("stalled sibling request context was not canceled")
+	}
+}
+
+func TestFetcher_ConcurrentStatsDuringRetries(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, _ *gohttp.Request) {
+		requests.Add(1)
+		w.WriteHeader(gohttp.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	f := buildFetcher(t)
+	target, err := os.CreateTemp(t.TempDir(), "gopeed-http-stats-race-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.file = target
+	f.meta = &fetcher.FetcherMeta{
+		Req: &base.Request{URL: server.URL},
+		Res: &base.Resource{Range: true, Size: 1},
+	}
+	f.connections = []*connection{
+		{ID: 0, Role: rolePrimary, State: connNotStarted, Chunk: newChunk(0, 0)},
+	}
+	startTestDownloadLoop(f)
+
+	stopStats := make(chan struct{})
+	var statsWG sync.WaitGroup
+	statsWG.Add(1)
+	go func() {
+		defer statsWG.Done()
+		ticker := time.NewTicker(100 * time.Microsecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stopStats:
+				return
+			case <-ticker.C:
+				_ = f.Stats()
+				_ = f.Progress()
+			}
+		}
+	}()
+	err = f.Wait()
+	close(stopStats)
+	statsWG.Wait()
+	if err == nil {
+		t.Fatal("Wait succeeded after repeated HTTP 400 responses")
+	}
+	if got := requests.Load(); got != 3 {
+		t.Fatalf("request count = %d, want 3", got)
+	}
+}
+
+func TestFetcher_StopPrefetchUnblocksReadBeforeCleanup(t *testing.T) {
+	f := buildFetcher(t)
+	body := newBlockingResponseBody()
+	f.resolveResp = &gohttp.Response{Body: body}
+	f.prefetchStopCh = make(chan struct{})
+	f.prefetchDoneCh = make(chan struct{})
+	f.prefetchStopOnce = sync.Once{}
+	f.prefetchDone.Store(false)
+	go f.asyncPrefetch()
+
+	select {
+	case <-body.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("prefetch read did not start")
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := f.stopPrefetchAndCopyData()
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("stop prefetch: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stopPrefetchAndCopyData remained blocked after closing the response")
+	}
+	if !f.prefetchDone.Load() {
+		t.Fatal("prefetch goroutine was still running during cleanup")
+	}
+	if f.prefetchFile != nil || f.prefetchFilePath != "" {
+		t.Fatal("prefetch temporary file was not cleaned up")
+	}
+}
+
+func TestFetcher_PrefetchCopyReturnsWriteError(t *testing.T) {
+	payload := []byte("prefetched response")
+	prefetchFile, err := os.CreateTemp(t.TempDir(), "gopeed-prefetch-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = prefetchFile.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	f := buildFetcher(t)
+	target := &failingTargetFile{err: syscall.ENOSPC}
+	f.file = target
+	f.prefetchFile = prefetchFile
+	f.prefetchFilePath = prefetchFile.Name()
+	f.prefetchSize.Store(int64(len(payload)))
+	f.prefetchDone.Store(true)
+
+	copied, err := f.stopPrefetchAndCopyData()
+	if !errors.Is(err, syscall.ENOSPC) {
+		t.Fatalf("copy error = %v, want ENOSPC", err)
+	}
+	if copied != 0 {
+		t.Fatalf("copied bytes = %d, want 0", copied)
+	}
+	if f.prefetchFile != nil || f.prefetchFilePath != "" {
+		t.Fatal("prefetch file was not cleaned up after copy failure")
+	}
+}
+
+func startTestDownloadLoop(f *Fetcher) {
+	run := newDownloadRun()
+	f.runMu.Lock()
+	f.run = run
+	f.runMu.Unlock()
+	f.setState(stateSlowStart)
+	go f.downloadLoop(run)
+}
+
+func assertFetcherWriteError(t *testing.T, f *Fetcher, target *failingTargetFile) {
+	t.Helper()
+	err := f.Wait()
+	<-f.currentRun().loopDone
+	select {
+	case duplicateErr := <-f.doneCh:
+		t.Fatalf("received duplicate completion error: %v", duplicateErr)
+	default:
+	}
+	if len(f.connections) != 1 {
+		t.Fatalf("connection count = %d, want 1", len(f.connections))
+	}
+	conn := f.connections[0]
+	if !errors.Is(err, syscall.ENOSPC) {
+		t.Fatalf("Wait() error = %v, want ENOSPC (state=%v connection=%v failed=%v lastErr=%v writes=%d)", err, f.getState(), conn.State, conn.failed, conn.lastErr, target.writes.Load())
+	}
+	if f.getState() != stateError {
+		t.Fatalf("fetcher state = %v, want %v", f.getState(), stateError)
+	}
+	if conn.State != connFailed || !conn.failed || !errors.Is(conn.lastErr, syscall.ENOSPC) {
+		t.Fatalf("connection state = %v, failed = %v, error = %v", conn.State, conn.failed, conn.lastErr)
+	}
+	if got := target.writes.Load(); got != 1 {
+		t.Fatalf("write count = %d, want 1", got)
+	}
+	if !target.closed.Load() {
+		t.Fatal("target file was not closed")
+	}
+}
+
 // TestFetcher_DownloadExpiringRedirectURL tests that the fetcher correctly handles
 // expiring redirect URLs by falling back to the original URL and getting a new redirect.
 func TestFetcher_DownloadExpiringRedirectURL(t *testing.T) {
@@ -919,7 +1250,7 @@ func TestFetcher_DownloadExpiringRedirectURL(t *testing.T) {
 		listener := test.StartTestExpiringRedirectServer(2, 100*time.Nanosecond)
 		defer listener.Close()
 
-		fetcher := buildFetcher()
+		fetcher := buildFetcher(t)
 		err := fetcher.Resolve(&base.Request{
 			URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 		}, &base.Options{
@@ -960,7 +1291,7 @@ func TestFetcher_DownloadExpiringRedirectURL(t *testing.T) {
 		listener := test.StartTestExpiringRedirectServer(5, 100*time.Nanosecond)
 		defer listener.Close()
 
-		fetcher := buildFetcher()
+		fetcher := buildFetcher(t)
 		err := fetcher.Resolve(&base.Request{
 			URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 		}, &base.Options{
@@ -1007,7 +1338,7 @@ func TestFetcher_RetryAfterError(t *testing.T) {
 	listener := test.StartTestFailThenRecoverServer(3)
 	defer listener.Close()
 
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 	}, &base.Options{
@@ -1040,11 +1371,16 @@ func TestFetcher_RetryAfterError(t *testing.T) {
 		t.Errorf("Expected fetcher to be in stateError, got %v", state)
 	}
 
-	// Verify that we can call Start() again after error
-	// This tests the stateError handling in Start()
-	err = fetcher.Start()
-	if err != nil {
-		t.Fatalf("Start() after error failed: %v", err)
+	// Concurrent retry requests must collapse into one new run. This exercises
+	// the state re-check after acquiring the lifecycle lock.
+	startErrCh := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() { startErrCh <- fetcher.Start() }()
+	}
+	for i := 0; i < 2; i++ {
+		if err = <-startErrCh; err != nil {
+			t.Fatalf("concurrent Start() after error failed: %v", err)
+		}
 	}
 
 	// Wait for second attempt - should succeed now that server has recovered
@@ -1112,7 +1448,7 @@ func TestFetcherManager_ParseName(t *testing.T) {
 }
 
 func downloadReady(listener net.Listener, connections int, t *testing.T) fetcher.Fetcher {
-	return doDownloadReady(buildFetcher(), listener, connections, t)
+	return doDownloadReady(buildFetcher(t), listener, connections, t)
 }
 
 func doDownloadReady(f fetcher.Fetcher, listener net.Listener, connections int, t *testing.T) fetcher.Fetcher {
@@ -1156,7 +1492,7 @@ func downloadNormal(listener net.Listener, connections int, t *testing.T) {
 func downloadPost(listener net.Listener, connections int, t *testing.T) {
 	// POST parameters must be set before Resolve since the new design
 	// starts downloading during Resolve phase
-	f := buildFetcher()
+	f := buildFetcher(t)
 	var extra any = nil
 	if connections > 0 {
 		extra = &http.OptsExtra{
@@ -1223,7 +1559,7 @@ func downloadContinue(listener net.Listener, connections int, t *testing.T) {
 }
 
 func downloadError(listener net.Listener, connections int, t *testing.T) {
-	fetcher := buildFetcher()
+	fetcher := buildFetcher(t)
 	err := fetcher.Resolve(&base.Request{
 		URL: "http://" + listener.Addr().String() + "/" + test.BuildName,
 	}, &base.Options{
@@ -1311,7 +1647,8 @@ func downloadWithProxy(httpListener net.Listener, proxyListener net.Listener, t 
 	}
 }
 
-func buildFetcher() *Fetcher {
+func buildFetcher(t *testing.T) *Fetcher {
+	t.Helper()
 	fm := new(FetcherManager)
 	fetcher := fm.Build()
 	newController := controller.NewController()
@@ -1319,7 +1656,9 @@ func buildFetcher() *Fetcher {
 		json.Unmarshal([]byte(test.ToJson(fm.DefaultConfig())), v)
 	}
 	fetcher.Setup(newController)
-	return fetcher.(*Fetcher)
+	result := fetcher.(*Fetcher)
+	t.Cleanup(func() { _ = result.Close() })
+	return result
 }
 
 func buildConfigFetcher(cfg config) fetcher.Fetcher {
@@ -1341,7 +1680,7 @@ func TestFetcher_Patch_URLChange(t *testing.T) {
 	listener := test.StartTestPatchURLServer()
 	defer listener.Close()
 
-	f := buildFetcher()
+	f := buildFetcher(t)
 	badURL := "http://" + listener.Addr().String() + "/bad-url"
 	goodURL := "http://" + listener.Addr().String() + "/good-url"
 
@@ -1359,7 +1698,7 @@ func TestFetcher_Patch_URLChange(t *testing.T) {
 
 	// Step 2: Create a new fetcher and resolve with bad URL but don't wait
 	// We need to test patching a task that has been created
-	f2 := buildFetcher()
+	f2 := buildFetcher(t)
 
 	// First resolve with good URL to create a valid fetcher state
 	err = f2.Resolve(&base.Request{URL: goodURL}, opts)
@@ -1407,7 +1746,7 @@ func TestFetcher_Patch_Labels(t *testing.T) {
 	listener := test.StartTestFileServer()
 	defer listener.Close()
 
-	f := buildFetcher()
+	f := buildFetcher(t)
 	opts := &base.Options{
 		Name:  test.DownloadName,
 		Path:  test.Dir,
@@ -1463,7 +1802,7 @@ func TestFetcher_Patch_Extra(t *testing.T) {
 	listener := test.StartTestFileServer()
 	defer listener.Close()
 
-	f := buildFetcher()
+	f := buildFetcher(t)
 	opts := &base.Options{
 		Name:  test.DownloadName,
 		Path:  test.Dir,
@@ -1552,7 +1891,7 @@ func TestFetcher_Patch_NilData(t *testing.T) {
 	listener := test.StartTestFileServer()
 	defer listener.Close()
 
-	f := buildFetcher()
+	f := buildFetcher(t)
 	opts := &base.Options{
 		Name:  test.DownloadName,
 		Path:  test.Dir,
@@ -1610,7 +1949,7 @@ func TestFetcher_Patch_CookieExpired(t *testing.T) {
 	}
 
 	// Step 1: Resolve with old_token - should succeed (first request accepts old_token)
-	f := buildFetcher()
+	f := buildFetcher(t)
 	err := f.Resolve(&base.Request{
 		URL: downloadURL,
 		Extra: &http.ReqExtra{

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -101,10 +101,12 @@ type Downloader struct {
 	waitTasks    []*Task
 	watchedTasks sync.Map
 	listener     Listener
+	listenerMu   sync.RWMutex
 
 	lock               *sync.Mutex
 	fetcherMapLock     *sync.RWMutex
 	checkDuplicateLock *sync.Mutex
+	extensionMu        sync.RWMutex
 	closed             atomic.Bool
 
 	// claimedExtractions tracks which multi-part archives have been claimed for extraction
@@ -221,9 +223,13 @@ func (d *Downloader) Setup() error {
 	d.cleanupNonExistingTasks()
 
 	// handle upload
-	go func() {
-		for _, task := range d.tasks {
-			if task.Status == base.DownloadStatusDone && task.Uploading {
+	uploadTasks := append([]*Task(nil), d.tasks...)
+	go func(tasks []*Task) {
+		for _, task := range tasks {
+			task.statusLock.Lock()
+			shouldUpload := task.Status == base.DownloadStatusDone && task.Uploading
+			task.statusLock.Unlock()
+			if shouldUpload {
 				if err := d.restoreTask(task); err != nil {
 					d.Logger.Error().Stack().Err(err).Msgf("task upload restore fetcher failed, task id: %s", task.ID)
 				}
@@ -234,26 +240,30 @@ func (d *Downloader) Setup() error {
 				}
 			}
 		}
-	}()
+	}(uploadTasks)
 
 	// calculate download speed every tick
 	go func() {
 		for !d.closed.Load() {
-			if len(d.tasks) > 0 {
-				for _, task := range d.tasks {
+			tasks := d.tasksSnapshot()
+			if len(tasks) > 0 {
+				for _, task := range tasks {
 					func() {
 						// Do not acquire d.lock (via GetTask) while holding
-						// statusLock; scheduling uses the opposite lock order.
+						// task.lock/statusLock; scheduling uses the opposite order.
 						if d.GetTask(task.ID) == nil {
 							return
 						}
+						task.lock.Lock()
 						task.statusLock.Lock()
 						if task.Status != base.DownloadStatusRunning && !task.Uploading {
 							task.statusLock.Unlock()
+							task.lock.Unlock()
 							return
 						}
 						if task.fetcher == nil {
 							task.statusLock.Unlock()
+							task.lock.Unlock()
 							return
 						}
 
@@ -276,14 +286,14 @@ func (d *Downloader) Setup() error {
 							task.Progress.Uploaded = currentUploaded
 						}
 						task.statusLock.Unlock()
-						// Listener callbacks may Pause/Continue and acquire statusLock.
-						d.emit(EventKeyProgress, task)
 
 						// store fetcher progress when download/upload data changed
-						if !downloadDataChanged && !uploadDataChanged {
-							return
+						if downloadDataChanged || uploadDataChanged {
+							d.saveTask(task)
 						}
-						d.saveTask(task)
+						task.lock.Unlock()
+						// Listener callbacks may Pause/Continue and acquire task.lock.
+						d.emit(EventKeyProgress, task)
 					}()
 				}
 			}
@@ -394,7 +404,10 @@ func (d *Downloader) saveTask(task *Task) error {
 			return err
 		}
 	}
-	if err := d.storage.Put(bucketTask, task.ID, task); err != nil {
+	task.statusLock.Lock()
+	taskCopy := task.clone()
+	task.statusLock.Unlock()
+	if err := d.storage.Put(bucketTask, task.ID, taskCopy); err != nil {
 		d.Logger.Error().Stack().Err(err).Msgf("persist task failed: %s", task.ID)
 		return err
 	}
@@ -447,6 +460,12 @@ func (d *Downloader) Resolve(req *base.Request, opts *base.Options) (rr *Resolve
 	if err != nil {
 		return
 	}
+	cacheOwnsFetcher := false
+	defer func() {
+		if !cacheOwnsFetcher {
+			err = errors.Join(err, fetcher.Close())
+		}
+	}()
 	initOpt, err := d.initOptions(opts)
 	if err != nil {
 		return
@@ -456,8 +475,14 @@ func (d *Downloader) Resolve(req *base.Request, opts *base.Options) (rr *Resolve
 		return
 	}
 	d.fetcherMapLock.Lock()
+	if d.closed.Load() {
+		d.fetcherMapLock.Unlock()
+		err = errors.New("downloader is closed")
+		return
+	}
 	d.fetcherCache[rrId] = fetcher
 	d.fetcherMapLock.Unlock()
+	cacheOwnsFetcher = true
 	rr = &ResolveResult{
 		ID:  rrId,
 		Res: fetcher.Meta().Res,
@@ -485,7 +510,7 @@ func (d *Downloader) notifyRunning() {
 func (d *Downloader) remainRunningCount() int {
 	runningCount := 0
 	for _, t := range d.tasks {
-		if t.Status == base.DownloadStatusRunning {
+		if d.taskStatus(t) == base.DownloadStatusRunning {
 			runningCount++
 		}
 	}
@@ -499,12 +524,20 @@ func (d *Downloader) CreateDirect(req *base.Request, opts *base.Options) (taskId
 	if err != nil {
 		return
 	}
+	taskOwnsFetcher := false
+	defer func() {
+		if !taskOwnsFetcher {
+			err = errors.Join(err, fetcher.Close())
+		}
+	}()
 	fetcher.Meta().Req = req
 	initOpt, err := d.initOptions(opts)
 	if err != nil {
 		return
 	}
-	return d.doCreate(fetcher, initOpt)
+	taskId, err = d.doCreate(fetcher, initOpt)
+	taskOwnsFetcher = taskId != ""
+	return
 }
 
 func (d *Downloader) CreateDirectBatch(req *base.CreateTaskBatch) (taskId []string, err error) {
@@ -524,18 +557,25 @@ func (d *Downloader) CreateDirectBatch(req *base.CreateTaskBatch) (taskId []stri
 }
 
 func (d *Downloader) Create(rrId string) (taskId string, err error) {
-	d.fetcherMapLock.RLock()
+	d.fetcherMapLock.Lock()
+	if d.closed.Load() {
+		d.fetcherMapLock.Unlock()
+		return "", errors.New("downloader is closed")
+	}
 	fetcher, ok := d.fetcherCache[rrId]
-	d.fetcherMapLock.RUnlock()
+	if ok {
+		delete(d.fetcherCache, rrId)
+	}
 	if !ok {
+		d.fetcherMapLock.Unlock()
 		return "", errors.New("invalid resource id")
 	}
-	defer func() {
-		d.fetcherMapLock.Lock()
-		delete(d.fetcherCache, rrId)
-		d.fetcherMapLock.Unlock()
-	}()
-	return d.doCreate(fetcher, nil)
+	taskId, err = d.doCreate(fetcher, nil)
+	d.fetcherMapLock.Unlock()
+	if taskId == "" {
+		err = errors.Join(err, fetcher.Close())
+	}
+	return taskId, err
 }
 
 // Patch modifies task-specific data based on the protocol.
@@ -607,15 +647,12 @@ func (d *Downloader) Pause(filter *TaskFilter) (err error) {
 }
 
 func (d *Downloader) pauseAll() (err error) {
-	func() {
-		d.lock.Lock()
-		defer d.lock.Unlock()
+	d.lock.Lock()
+	d.waitTasks = d.waitTasks[:0]
+	tasks := append([]*Task(nil), d.tasks...)
+	d.lock.Unlock()
 
-		// Clear wait tasks
-		d.waitTasks = d.waitTasks[:0]
-	}()
-
-	for _, task := range d.tasks {
+	for _, task := range tasks {
 		if err = d.doPause(task); err != nil {
 			return
 		}
@@ -867,6 +904,7 @@ func (d *Downloader) Close() error {
 	d.closed.Store(true)
 
 	closeArr := []func() error{
+		d.closeFetcherCache,
 		d.pauseAll,
 	}
 	for _, fm := range d.cfg.FetchManagers {
@@ -887,14 +925,32 @@ func (d *Downloader) Close() error {
 	return lastErr
 }
 
+func (d *Downloader) closeFetcherCache() error {
+	d.fetcherMapLock.Lock()
+	cache := d.fetcherCache
+	d.fetcherCache = make(map[string]fetcher.Fetcher)
+	d.fetcherMapLock.Unlock()
+
+	var closeErr error
+	for _, f := range cache {
+		closeErr = errors.Join(closeErr, f.Close())
+	}
+	return closeErr
+}
+
 func (d *Downloader) Clear() error {
 	if !d.closed.Load() {
 		if err := d.Close(); err != nil {
 			return err
 		}
 	}
+	d.lock.Lock()
 	d.tasks = make([]*Task, 0)
+	d.waitTasks = make([]*Task, 0)
+	d.lock.Unlock()
+	d.extensionMu.Lock()
 	d.extensions = make([]*Extension, 0)
+	d.extensionMu.Unlock()
 	if err := d.storage.Clear(); err != nil {
 		return err
 	}
@@ -922,16 +978,21 @@ func (s *protocolStateStore) Delete() error {
 }
 
 func (d *Downloader) Listener(fn Listener) {
+	d.listenerMu.Lock()
 	d.listener = fn
+	d.listenerMu.Unlock()
 }
 
 func (d *Downloader) emit(eventKey EventKey, task *Task, errs ...error) {
-	if d.listener != nil {
+	d.listenerMu.RLock()
+	listener := d.listener
+	d.listenerMu.RUnlock()
+	if listener != nil {
 		var err error
 		if len(errs) > 0 {
 			err = errs[0]
 		}
-		d.listener(&Event{
+		listener(&Event{
 			Key:  eventKey,
 			Task: task,
 			Err:  err,
@@ -955,7 +1016,13 @@ func (d *Downloader) GetTasks() []*Task {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	return d.tasks
+	return append([]*Task(nil), d.tasks...)
+}
+
+func (d *Downloader) tasksSnapshot() []*Task {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return append([]*Task(nil), d.tasks...)
 }
 
 // GetTasksByFilter get tasks by filter, if filter is nil, return all tasks
@@ -965,7 +1032,7 @@ func (d *Downloader) GetTasksByFilter(filter *TaskFilter) []*Task {
 	defer d.lock.Unlock()
 
 	if filter == nil || filter.IsEmpty() {
-		return d.tasks
+		return append([]*Task(nil), d.tasks...)
 	}
 
 	idMatch := func(task *Task) bool {
@@ -983,8 +1050,9 @@ func (d *Downloader) GetTasksByFilter(filter *TaskFilter) []*Task {
 		if len(filter.Statuses) == 0 {
 			return true
 		}
+		taskStatus := d.taskStatus(task)
 		for _, status := range filter.Statuses {
-			if task.Status == status {
+			if taskStatus == status {
 				return true
 			}
 		}
@@ -994,8 +1062,9 @@ func (d *Downloader) GetTasksByFilter(filter *TaskFilter) []*Task {
 		if len(filter.NotStatuses) == 0 {
 			return true
 		}
+		taskStatus := d.taskStatus(task)
 		for _, status := range filter.NotStatuses {
-			if task.Status == status {
+			if taskStatus == status {
 				return false
 			}
 		}
@@ -1045,7 +1114,10 @@ func (d *Downloader) watch(task *Task) {
 	}()
 
 	// wait task upload done
-	if task.Uploading {
+	task.statusLock.Lock()
+	uploading := task.Uploading
+	task.statusLock.Unlock()
+	if uploading {
 		if uploader, ok := task.fetcher.(fetcher.Uploader); ok {
 			go func() {
 				err := uploader.WaitUpload()
@@ -1055,8 +1127,11 @@ func (d *Downloader) watch(task *Task) {
 
 				// Check if the task is deleted
 				if d.GetTask(task.ID) != nil {
+					task.statusLock.Lock()
 					task.Uploading = false
-					d.storage.Put(bucketTask, task.ID, task.clone())
+					taskCopy := task.clone()
+					task.statusLock.Unlock()
+					d.storage.Put(bucketTask, task.ID, taskCopy)
 				}
 			}()
 		}
@@ -1088,12 +1163,19 @@ func (d *Downloader) watch(task *Task) {
 			return
 		}
 
-		// When delete a not resolved task, need check if the task resource is nil
-		if task.Meta.Res == nil || d.GetTask(task.ID) == nil {
+		// Check membership before task.lock to preserve the global lock order.
+		if d.GetTask(task.ID) == nil {
+			return
+		}
+		task.lock.Lock()
+		// When deleting a task that has not resolved, the resource can be nil.
+		if task.Meta == nil || task.Meta.Res == nil {
+			task.lock.Unlock()
 			return
 		}
 		if d.blob != nil && task.Meta.Req != nil {
 			if err := d.blob.SourceError(task.Meta.Req.URL); err != nil {
+				task.lock.Unlock()
 				d.doOnBlobSourceError(task, err)
 				if d.taskStatus(task) == base.DownloadStatusRunning {
 					continue
@@ -1114,16 +1196,23 @@ func (d *Downloader) watch(task *Task) {
 		task.Progress.Speed = totalSize / used
 		task.Progress.Downloaded = totalSize
 		if !d.markTaskDone(task) {
+			task.lock.Unlock()
 			return
 		}
-		d.storage.Put(bucketTask, task.ID, task.clone())
+		task.statusLock.Lock()
+		taskCopy := task.clone()
+		task.statusLock.Unlock()
+		d.storage.Put(bucketTask, task.ID, taskCopy)
+		task.lock.Unlock()
 		d.emit(EventKeyDone, task)
-		d.emit(EventKeyFinally, task, err)
 		d.notifyRunning()
 		d.releaseBlobTask(task)
 		d.triggerOnDone(task)
 		d.triggerWebhooks(WebhookEventDownloadDone, task, nil)
 		d.triggerScripts(ScriptEventDownloadDone, task, nil)
+		// Finally is emitted after synchronous completion hooks so listeners
+		// observe all task mutations performed by onDone extensions.
+		d.emit(EventKeyFinally, task, err)
 
 		if e, ok := task.Meta.Opts.Extra.(*http.OptsExtra); ok {
 			downloadFilePath := task.Meta.SingleFilepath()
@@ -1198,7 +1287,7 @@ func (d *Downloader) handleOnError(task *Task, err error, resetFetcher bool) {
 		return
 	}
 	task.lock.Lock()
-	if !d.markTaskError(task) {
+	if !d.markTaskError(task, err) {
 		task.lock.Unlock()
 		return
 	}
@@ -1228,8 +1317,17 @@ func (d *Downloader) handleOnError(task *Task, err error, resetFetcher bool) {
 			d.Logger.Warn().Err(resetErr).Msgf("reset recovered task fetcher failed, task id: %s", task.ID)
 		}
 	}
+	failed := d.taskStatus(task) == base.DownloadStatusError
+	if failed {
+		task.statusLock.Lock()
+		snapshot := task.clone()
+		task.statusLock.Unlock()
+		if saveErr := d.storage.Put(bucketTask, task.ID, snapshot); saveErr != nil {
+			d.Logger.Warn().Err(saveErr).Msgf("persist task error failed, task id: %s", task.ID)
+		}
+	}
 	task.lock.Unlock()
-	if d.taskStatus(task) == base.DownloadStatusError {
+	if failed {
 		d.releaseBlobTask(task)
 		d.emit(EventKeyError, task, err)
 		d.emit(EventKeyFinally, task, err)
@@ -1409,6 +1507,7 @@ func (d *Downloader) doStart(task *Task) (err error) {
 		}
 		isCreate = task.Status == base.DownloadStatusReady
 		task.updateStatus(base.DownloadStatusRunning)
+		task.Error = ""
 		task.runGeneration++
 		generation = task.runGeneration
 
@@ -1631,11 +1730,12 @@ func (d *Downloader) markTaskDone(task *Task) bool {
 		return false
 	}
 	task.updateStatus(base.DownloadStatusDone)
+	task.Error = ""
 	task.runGeneration++
 	return true
 }
 
-func (d *Downloader) markTaskError(task *Task) bool {
+func (d *Downloader) markTaskError(task *Task, err error) bool {
 	if task == nil || task.statusLock == nil {
 		return false
 	}
@@ -1645,6 +1745,11 @@ func (d *Downloader) markTaskError(task *Task) bool {
 		return false
 	}
 	task.updateStatus(base.DownloadStatusError)
+	if err != nil {
+		task.Error = err.Error()
+	} else {
+		task.Error = "download failed"
+	}
 	task.runGeneration++
 	return true
 }

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -32,6 +32,7 @@ import (
 type generationTestManager struct {
 	starts         atomic.Int32
 	pauses         atomic.Int32
+	closes         atomic.Int32
 	holdOpen       bool
 	resolveStarted chan struct{}
 	resolveRelease <-chan struct{}
@@ -105,6 +106,18 @@ type generationTestFetcher struct {
 	done    chan error
 }
 
+type failingTaskPutStorage struct {
+	Storage
+	fail atomic.Bool
+}
+
+func (s *failingTaskPutStorage) Put(bucket string, key string, value any) error {
+	if s.fail.Load() && bucket == bucketTask {
+		return errors.New("injected task persistence failure")
+	}
+	return s.Storage.Put(bucket, key, value)
+}
+
 func (f *generationTestFetcher) Setup(*controller.Controller) {
 	if f.done == nil {
 		f.done = make(chan error, 2)
@@ -151,7 +164,10 @@ func (f *generationTestFetcher) Pause() error {
 	}
 	return nil
 }
-func (f *generationTestFetcher) Close() error               { return nil }
+func (f *generationTestFetcher) Close() error {
+	f.manager.closes.Add(1)
+	return nil
+}
 func (f *generationTestFetcher) Stats() any                 { return nil }
 func (f *generationTestFetcher) Meta() *fetcher.FetcherMeta { return f.meta }
 func (f *generationTestFetcher) Progress() fetcher.Progress { return fetcher.Progress{1} }
@@ -201,6 +217,80 @@ func TestDownloader_Resolve(t *testing.T) {
 	}
 	if !test.AssertResourceEqual(want, rr.Res) {
 		t.Errorf("Resolve() got = %v, want %v", rr.Res, want)
+	}
+}
+
+func TestDownloaderCloseReleasesCachedResolvedFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	downloader := NewDownloader(&DownloaderConfig{FetchManagers: []fetcher.FetcherManager{manager}})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := downloader.Resolve(
+		&base.Request{URL: "generation://cached"},
+		&base.Options{Path: t.TempDir(), Name: "generation.bin"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.closes.Load(); got != 0 {
+		t.Fatalf("cached fetcher closed before Downloader.Close: %d", got)
+	}
+	if err := downloader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.closes.Load(); got != 1 {
+		t.Fatalf("cached fetcher close count = %d, want 1", got)
+	}
+}
+
+func TestDownloaderCreateFailureClosesCachedFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	storage := &failingTaskPutStorage{Storage: NewMemStorage()}
+	downloader := NewDownloader(&DownloaderConfig{
+		FetchManagers: []fetcher.FetcherManager{manager},
+		Storage:       storage,
+	})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = downloader.Close() })
+
+	resolved, err := downloader.Resolve(
+		&base.Request{URL: "generation://create-failure"},
+		&base.Options{Path: t.TempDir(), Name: "generation.bin"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storage.fail.Store(true)
+	if _, err = downloader.Create(resolved.ID); err == nil {
+		t.Fatal("Create succeeded with injected persistence failure")
+	}
+	if got := manager.closes.Load(); got != 1 {
+		t.Fatalf("failed Create fetcher close count = %d, want 1", got)
+	}
+}
+
+func TestDownloaderCreateDirectOptionFailureClosesFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	downloader := NewDownloader(&DownloaderConfig{
+		FetchManagers:     []fetcher.FetcherManager{manager},
+		WhiteDownloadDirs: []string{filepath.Join(t.TempDir(), "allowed")},
+	})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = downloader.Close() })
+
+	if _, err := downloader.CreateDirect(
+		&base.Request{URL: "generation://direct-option-failure"},
+		&base.Options{Path: t.TempDir(), Name: "generation.bin"},
+	); err == nil {
+		t.Fatal("CreateDirect succeeded outside the download directory allowlist")
+	}
+	if got := manager.closes.Load(); got != 1 {
+		t.Fatalf("failed CreateDirect fetcher close count = %d, want 1", got)
 	}
 }
 
@@ -378,6 +468,85 @@ func TestDownloader_RegistryMissUsesOrdinaryHTTPError(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("Registry miss did not reach the ordinary HTTP error path")
+	}
+}
+
+func TestDownloaderPersistsDownloadError(t *testing.T) {
+	storage := NewMemStorage()
+	if err := storage.Setup([]string{bucketTask}); err != nil {
+		t.Fatal(err)
+	}
+	downloader := NewDownloader(&DownloaderConfig{
+		Storage:               storage,
+		DownloaderStoreConfig: (&base.DownloaderStoreConfig{}).Init(),
+	})
+	task := NewTask()
+	task.Meta = &fetcher.FetcherMeta{
+		Req:  &base.Request{URL: "https://example.com/file"},
+		Opts: &base.Options{Path: t.TempDir(), Name: "file"},
+	}
+	task.Progress = &Progress{}
+	initTask(task)
+	task.Status = base.DownloadStatusRunning
+	if err := storage.Put(bucketTask, task.ID, task.clone()); err != nil {
+		t.Fatal(err)
+	}
+	diskErr := errors.New("no space left on device")
+	downloader.handleOnError(task, diskErr, false)
+
+	task.statusLock.Lock()
+	status, errorMessage := task.Status, task.Error
+	task.statusLock.Unlock()
+	if status != base.DownloadStatusError || errorMessage != diskErr.Error() {
+		t.Fatalf("unexpected disk-full task state: status=%s error=%q", status, errorMessage)
+	}
+	var persisted Task
+	if ok, err := storage.Get(bucketTask, task.ID, &persisted); err != nil || !ok {
+		t.Fatalf("load persisted task: ok=%v err=%v", ok, err)
+	}
+	if persisted.Status != base.DownloadStatusError || persisted.Error != diskErr.Error() {
+		t.Fatalf("unexpected persisted disk-full state: %#v", persisted)
+	}
+}
+
+func TestDownloaderErrorAndRestartStateRemainConsistent(t *testing.T) {
+	downloader := NewDownloader(nil)
+	diskErr := errors.New("no space left on device")
+
+	for i := 0; i < 1000; i++ {
+		task := NewTask()
+		task.Progress = &Progress{}
+		initTask(task)
+		task.Status = base.DownloadStatusRunning
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			downloader.markTaskError(task, diskErr)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = downloader.statusMut(task, func() (bool, error) {
+				if task.Status == base.DownloadStatusError {
+					task.updateStatus(base.DownloadStatusRunning)
+					task.Error = ""
+					task.runGeneration++
+				}
+				return false, nil
+			})
+		}()
+		wg.Wait()
+
+		task.statusLock.Lock()
+		status, errorMessage := task.Status, task.Error
+		task.statusLock.Unlock()
+		if status == base.DownloadStatusRunning && errorMessage != "" {
+			t.Fatalf("iteration %d: running task retained error %q", i, errorMessage)
+		}
+		if status == base.DownloadStatusError && errorMessage != diskErr.Error() {
+			t.Fatalf("iteration %d: error task has message %q", i, errorMessage)
+		}
 	}
 }
 

--- a/pkg/download/extension.go
+++ b/pkg/download/extension.go
@@ -64,7 +64,9 @@ func (d *Downloader) InstallExtensionByFolder(path string, devMode bool) (*Exten
 	}
 
 	// if extension is not installed, add it to the list, otherwise update it
-	installedExt := d.getExtension(ext.Identity)
+	d.extensionMu.Lock()
+	defer d.extensionMu.Unlock()
+	installedExt := d.getExtensionLocked(ext.Identity)
 	if installedExt == nil {
 		ext.CreatedAt = time.Now()
 		ext.UpdatedAt = ext.CreatedAt
@@ -118,9 +120,11 @@ func (d *Downloader) UpgradeExtension(identity string) error {
 }
 
 func (d *Downloader) UpdateExtensionSettings(identity string, settings map[string]any) error {
-	ext, err := d.GetExtension(identity)
-	if err != nil {
-		return err
+	d.extensionMu.Lock()
+	defer d.extensionMu.Unlock()
+	ext := d.getExtensionLocked(identity)
+	if ext == nil {
+		return ErrExtensionNotFound
 	}
 	for _, setting := range ext.Settings {
 		if value, ok := settings[setting.Name]; ok {
@@ -131,18 +135,22 @@ func (d *Downloader) UpdateExtensionSettings(identity string, settings map[strin
 }
 
 func (d *Downloader) SwitchExtension(identity string, status bool) error {
-	ext, err := d.GetExtension(identity)
-	if err != nil {
-		return err
+	d.extensionMu.Lock()
+	defer d.extensionMu.Unlock()
+	ext := d.getExtensionLocked(identity)
+	if ext == nil {
+		return ErrExtensionNotFound
 	}
 	ext.Disabled = !status
 	return d.storage.Put(bucketExtension, ext.Identity, ext)
 }
 
 func (d *Downloader) DeleteExtension(identity string) error {
-	ext, err := d.GetExtension(identity)
-	if err != nil {
-		return err
+	d.extensionMu.Lock()
+	defer d.extensionMu.Unlock()
+	ext := d.getExtensionLocked(identity)
+	if ext == nil {
+		return ErrExtensionNotFound
 	}
 	// remove from disk
 	if !ext.DevMode {
@@ -157,28 +165,38 @@ func (d *Downloader) DeleteExtension(identity string) error {
 			break
 		}
 	}
-	if err = d.storage.Delete(bucketExtension, identity); err != nil {
+	if err := d.storage.Delete(bucketExtension, identity); err != nil {
 		return err
 	}
-	if err = d.storage.Delete(bucketExtensionStorage, identity); err != nil {
+	if err := d.storage.Delete(bucketExtensionStorage, identity); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (d *Downloader) GetExtensions() []*Extension {
-	return d.extensions
+	d.extensionMu.RLock()
+	defer d.extensionMu.RUnlock()
+	return *util.DeepClone(&d.extensions)
 }
 
 func (d *Downloader) GetExtension(identity string) (*Extension, error) {
-	extension := d.getExtension(identity)
+	d.extensionMu.RLock()
+	defer d.extensionMu.RUnlock()
+	extension := d.getExtensionLocked(identity)
 	if extension == nil {
 		return nil, ErrExtensionNotFound
 	}
-	return extension, nil
+	return util.DeepClone(extension), nil
 }
 
 func (d *Downloader) getExtension(identity string) *Extension {
+	d.extensionMu.RLock()
+	defer d.extensionMu.RUnlock()
+	return d.getExtensionLocked(identity)
+}
+
+func (d *Downloader) getExtensionLocked(identity string) *Extension {
 	for _, ext := range d.extensions {
 		if ext.Identity == identity {
 			return ext
@@ -326,7 +344,10 @@ func doTrigger[T any](d *Downloader, event ActivationEvent, req *base.Request, c
 		Events: make(InstanceEvents),
 	}
 	var err error
-	for _, ext := range d.extensions {
+	d.extensionMu.RLock()
+	extensions := *util.DeepClone(&d.extensions)
+	d.extensionMu.RUnlock()
+	for _, ext := range extensions {
 		if ext.Disabled {
 			continue
 		}
@@ -733,6 +754,14 @@ type OnErrorExtensionTask struct {
 }
 
 func cloneExtensionTask(task *Task) *Task {
+	if task.blobRefLock != nil {
+		task.blobRefLock.Lock()
+		defer task.blobRefLock.Unlock()
+	}
+	if task.statusLock != nil {
+		task.statusLock.Lock()
+		defer task.statusLock.Unlock()
+	}
 	newTask := task.clone()
 	newTask.Meta.Req = task.Meta.Req
 	return newTask

--- a/pkg/download/extension_test.go
+++ b/pkg/download/extension_test.go
@@ -876,16 +876,28 @@ func TestDownloader_Extension_BlobPauseContinueKeepsSource(t *testing.T) {
 			waitForFileSizeAtLeast(t, filePath, 4096, 2*time.Second)
 
 			task := downloader.GetTask(id)
-			if task == nil || task.Meta == nil || task.Meta.Req == nil {
+			if task == nil {
+				t.Fatal("task request missing before pause")
+			}
+			task.lock.Lock()
+			if task.Meta == nil || task.Meta.Req == nil {
+				task.lock.Unlock()
 				t.Fatal("task request missing before pause")
 			}
 			oldURL := task.Meta.Req.URL
+			task.lock.Unlock()
 
 			if err := downloader.Pause(&TaskFilter{IDs: []string{id}}); err != nil {
 				t.Fatal(err)
 			}
 			task = downloader.GetTask(id)
-			if task == nil || task.Status != base.DownloadStatusPause {
+			if task == nil {
+				t.Fatal("paused task disappeared")
+			}
+			task.statusLock.Lock()
+			paused := task.Status == base.DownloadStatusPause
+			task.statusLock.Unlock()
+			if !paused {
 				t.Fatalf("expected paused task, got %#v", task)
 			}
 			if !downloader.blob.IsURL(oldURL) {
@@ -2000,7 +2012,10 @@ func waitForTaskTerminal(t *testing.T, downloader *Downloader, id string, timeou
 	for time.Now().Before(deadline) {
 		task := downloader.GetTask(id)
 		if task != nil {
-			switch task.Status {
+			task.statusLock.Lock()
+			status := task.Status
+			task.statusLock.Unlock()
+			switch status {
 			case base.DownloadStatusDone:
 				return
 			case base.DownloadStatusError:
@@ -2035,7 +2050,10 @@ func waitForTaskTerminal(t *testing.T, downloader *Downloader, id string, timeou
 		if task == nil {
 			t.Fatalf("timeout waiting for task %s: task not found", id)
 		}
-		t.Fatalf("timeout waiting for task %s: status=%s downloaded=%d total=%d", id, task.Status, task.Progress.Downloaded, task.Meta.Res.Size)
+		task.statusLock.Lock()
+		status, downloaded := task.Status, task.Progress.Downloaded
+		task.statusLock.Unlock()
+		t.Fatalf("timeout waiting for task %s: status=%s downloaded=%d total=%d", id, status, downloaded, task.Meta.Res.Size)
 	}
 }
 
@@ -2044,8 +2062,13 @@ func waitForTaskStatus(t *testing.T, downloader *Downloader, id string, status b
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		task := downloader.GetTask(id)
-		if task != nil && task.Status == status {
-			return
+		if task != nil {
+			task.statusLock.Lock()
+			currentStatus := task.Status
+			task.statusLock.Unlock()
+			if currentStatus == status {
+				return
+			}
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -2057,5 +2080,8 @@ func waitForTaskStatus(t *testing.T, downloader *Downloader, id string, status b
 	if task.Meta != nil && task.Meta.Res != nil {
 		total = task.Meta.Res.Size
 	}
-	t.Fatalf("timeout waiting for task %s status %s: got %s downloaded=%d total=%d", id, status, task.Status, task.Progress.Downloaded, total)
+	task.statusLock.Lock()
+	currentStatus, downloaded := task.Status, task.Progress.Downloaded
+	task.statusLock.Unlock()
+	t.Fatalf("timeout waiting for task %s status %s: got %s downloaded=%d total=%d", id, status, currentStatus, downloaded, total)
 }

--- a/pkg/download/model.go
+++ b/pkg/download/model.go
@@ -27,6 +27,7 @@ type Task struct {
 	Meta      *fetcher.FetcherMeta `json:"meta"`
 	Status    base.Status          `json:"status"`
 	Uploading bool                 `json:"uploading"`
+	Error     string               `json:"error,omitempty"`
 	Progress  *Progress            `json:"progress"`
 	CreatedAt time.Time            `json:"createdAt"`
 	UpdatedAt time.Time            `json:"updatedAt"`

--- a/pkg/download/webhook_test.go
+++ b/pkg/download/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -191,14 +192,14 @@ func TestWebhook_NoWebhookConfigured(t *testing.T) {
 }
 
 func TestWebhook_MultipleUrls(t *testing.T) {
-	count := 0
+	var count atomic.Int32
 	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count++
+		count.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server1.Close()
 	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		count++
+		count.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server2.Close()
@@ -223,8 +224,8 @@ func TestWebhook_MultipleUrls(t *testing.T) {
 		// Wait for webhooks
 		time.Sleep(500 * time.Millisecond)
 
-		if count != 2 {
-			t.Errorf("Expected 2 webhook calls, got %d", count)
+		if got := count.Load(); got != 2 {
+			t.Errorf("Expected 2 webhook calls, got %d", got)
 		}
 	})
 }
@@ -630,9 +631,9 @@ func TestWebhook_SendWebhookToUrl_VariousStatusCodes(t *testing.T) {
 }
 
 func TestWebhook_TriggerWebhooks_EmptyUrlSkipped(t *testing.T) {
-	requestCount := 0
+	var requestCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
+		requestCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -653,8 +654,8 @@ func TestWebhook_TriggerWebhooks_EmptyUrlSkipped(t *testing.T) {
 
 		time.Sleep(500 * time.Millisecond)
 
-		if requestCount != 2 {
-			t.Errorf("Expected 2 requests (empty URL should be skipped), got %d", requestCount)
+		if got := requestCount.Load(); got != 2 {
+			t.Errorf("Expected 2 requests (empty URL should be skipped), got %d", got)
 		}
 	})
 }

--- a/ui/flutter/lib/api/model/task.dart
+++ b/ui/flutter/lib/api/model/task.dart
@@ -30,6 +30,7 @@ class Task {
   Meta meta;
   Status status;
   bool uploading;
+  String? error;
   Progress progress;
   DateTime createdAt;
   DateTime updatedAt;
@@ -40,6 +41,7 @@ class Task {
     required this.meta,
     required this.status,
     required this.uploading,
+    this.error,
     required this.progress,
     required this.createdAt,
     required this.updatedAt,

--- a/ui/flutter/lib/api/model/task.g.dart
+++ b/ui/flutter/lib/api/model/task.g.dart
@@ -12,6 +12,7 @@ Task _$TaskFromJson(Map<String, dynamic> json) => Task(
       meta: Meta.fromJson(json['meta'] as Map<String, dynamic>),
       status: $enumDecode(_$StatusEnumMap, json['status']),
       uploading: json['uploading'] as bool,
+      error: json['error'] as String?,
       progress: Progress.fromJson(json['progress'] as Map<String, dynamic>),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
@@ -33,6 +34,7 @@ Map<String, dynamic> _$TaskToJson(Task instance) {
   val['meta'] = instance.meta.toJson();
   val['status'] = _$StatusEnumMap[instance.status]!;
   val['uploading'] = instance.uploading;
+  writeNotNull('error', instance.error);
   val['progress'] = instance.progress.toJson();
   val['createdAt'] = instance.createdAt.toIso8601String();
   val['updatedAt'] = instance.updatedAt.toIso8601String();

--- a/ui/flutter/lib/app/views/buid_task_list_view.dart
+++ b/ui/flutter/lib/app/views/buid_task_list_view.dart
@@ -620,6 +620,27 @@ class BuildTaskListView extends GetView {
                       : LinearProgressIndicator(
                           value: getProgress(),
                         ),
+                  if (task.status == Status.error &&
+                      task.error?.isNotEmpty == true)
+                    Row(
+                      children: [
+                        const Icon(Icons.error_outline,
+                            size: 16, color: Colors.red),
+                        const SizedBox(width: 4),
+                        Expanded(
+                          child: Tooltip(
+                            message: task.error!,
+                            child: Text(
+                              task.error!,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: Get.textTheme.bodySmall
+                                  ?.copyWith(color: Colors.red),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ).padding(left: 18, right: 18, top: 4, bottom: 8),
                   // Extraction status row
                   if (task.progress.extractStatus != ExtractStatus.none)
                     Builder(builder: (context) {


### PR DESCRIPTION
## Summary

- Surface local storage write failures, including `ENOSPC` and short writes, as terminal HTTP and BitTorrent task errors.
- Persist the underlying error on the task and show it in the Flutter task list instead of leaving the task in a healthy-looking running state.
- Make retry, pause, close, shared-torrent teardown, and asynchronous storage callbacks generation-safe.
- Close or transfer every fetcher resource explicitly and synchronize progress persistence, listeners, extensions, and callback state.

## Problem

When the download target runs out of space, a storage write can fail after the protocol has already entered its asynchronous download loop. The failure was not consistently delivered to `Fetcher.Wait`, so the downloader and UI could continue to present the task as running without explaining the local storage failure.

A narrow `WriteAt` error check is not sufficient here:

- HTTP retries can overlap the previous run's completion publication and consume stale errors or reuse lifecycle state that is still active.
- BitTorrent storage callbacks are asynchronous and a torrent can be shared by multiple fetchers. A delayed callback from an old run must not fail or disable a newer retry, while a current write failure must reach every subscriber.
- Resolved fetchers can temporarily live in the downloader cache and need an explicit ownership transfer or close path on every failure and shutdown branch.
- Progress persistence and UI polling run concurrently with active connections and must snapshot state without racing the download hot path.

## Changes and review order

The branch intentionally keeps the work split into four reviewable commits:

1. `fix(http): isolate download runs and storage failures`
   - Gives each `Start` invocation its own context, result, and loop lifetime.
   - Treats target write and short-write failures as terminal, cancels sibling connections, and closes the target before completion is published.
   - Serializes `Start`, `Pause`, and `Close` and snapshots connection persistence state under synchronization.

2. `fix(bt): synchronize shared torrent error lifecycles`
   - Broadcasts a storage failure to every fetcher sharing the torrent.
   - Associates asynchronous callbacks with torrent epochs so stale callbacks cannot affect a later retry.
   - Serializes subscriber registration, last-owner `Drop`, client shutdown, and `Start`/`Allow` transitions.
   - Merges reusable `TorrentSpec` fields safely and applies trackers before torrent creation to avoid a live tracker update race.

3. `fix(download): preserve fetcher ownership and task errors`
   - Transfers cached fetcher ownership atomically, closes fetchers on all pre-task failures, and drains the resolve cache during shutdown.
   - Makes task status, error text, run generations, scheduling, persistence snapshots, and listener access concurrency-safe.
   - Adds the optional `Task.error` API field and renders it in the Flutter task list.

4. `fix(download): synchronize extension and callback state`
   - Protects extension registration, lookup, enablement, and runtime snapshots.
   - Keeps reentrant listener callbacks outside task lifecycle locks and synchronizes blob leases and webhook observers.

## Lifecycle invariants

- A download run owns exactly one context, terminal result, and completion signal.
- A target write failure is terminal for that run and is published only after sibling workers and the target file have been cleaned up.
- A BitTorrent callback can only affect the torrent epoch that created it.
- A shared torrent is dropped only by its last registered owner.
- A fetcher is always owned by the resolve cache, by a task, or by the caller that must close it; ownership is never implicit.
- Listener and extension callbacks are invoked from stable snapshots and outside locks that they may re-enter.

## UI verification

The task now enters the error state and displays the underlying local write failure:

![HTTP ENOSPC error shown in the task list](https://raw.githubusercontent.com/wentf9/gopeed/pr-assets-disk-full-error/_docs/img/pr/http-enospc-error.png)

## Tests

Passed locally:

```text
go test ./internal/protocol/http
go test ./internal/protocol/bt
go test ./pkg/download
```

New coverage includes:

- HTTP range and non-range target write failures.
- Short writes, sibling cancellation, prefetch cleanup, retry generations, and concurrent `Stats`/`Progress` access.
- Shared-torrent error fan-out, delayed callbacks from an earlier epoch, concurrent shared resolve/close, and tracker/spec reuse.
- Resolve-cache shutdown, task creation failure cleanup, persisted task errors, and restart/error generation consistency.
- Concurrent extension state and deterministic callback synchronization.

The modified Dart model and task-list files also pass `dart format --output=none --set-exit-if-changed`.

## Performance investigation

An apparent LAN throughput regression was investigated before opening this PR:

- Controlled loopback tests of the complete `Resolve -> Start -> Wait` path, with 1/16/32/64 connections, showed the branch and `main` within normal variance at roughly 1.3-1.7 GiB/s.
- The real AList/Unraid source returned about 11.8 MB/s for a cold 256 MiB range, then about 201.7 MB/s for the exact same range and about 270.2 MB/s for an adjacent range.

This identified server-side cold-cache/storage behavior and test ordering as the cause; no fixed client-side throughput limit was found.

## Compatibility and risk

- `Task.error` is an additive optional JSON field.
- Successful download behavior and public control methods are intended to remain compatible.
- The patch changes protocol and downloader lifecycle synchronization substantially, so this PR is opened as a draft for focused review of ownership, lock ordering, callback generations, and teardown behavior.
