### PR TITLE
fix(http): make Resolve prefetch lifecycle-safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/xiaoqidun/setft v0.0.0-20220310121541-be86327699ad
 	go.etcd.io/bbolt v1.4.3
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93
+	golang.org/x/sys v0.40.0
 )
 
 require (
@@ -150,7 +151,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect

--- a/internal/protocol/http/fetcher.go
+++ b/internal/protocol/http/fetcher.go
@@ -284,11 +284,15 @@ type Fetcher struct {
 
 	// Async prefetch during resolve phase
 	prefetchFile     *os.File      // Temporary file for prefetch data
-	prefetchFilePath string        // Path to temporary file
+	prefetchFilePath string        // Path used to create the temporary file (unlinked immediately on POSIX)
+	prefetchDirPath  string        // Private temporary directory used on Windows
 	prefetchSize     atomic.Int64  // Bytes prefetched so far
 	prefetchDone     atomic.Bool   // Prefetch completed or stopped
 	prefetchErr      error         // Error during prefetch (if any)
 	prefetchStopCh   chan struct{} // Signal to stop prefetch
+	prefetchDoneCh   chan struct{} // Closed after the prefetch goroutine has completely exited
+	prefetchStopOnce sync.Once     // Makes stopping safe across Start/Pause/takeover races
+	prefetchDoneOnce sync.Once     // Makes the goroutine completion signal single-shot
 	resolveFallback  atomic.Bool   // Resolve prefetch is still available until the first Range request takes over
 
 	// Target file
@@ -408,7 +412,7 @@ func (f *Fetcher) Resolve(req *base.Request, opts *base.Options) error {
 	}
 
 	if resp.StatusCode != base.HttpCodeOK && resp.StatusCode != base.HttpCodePartialContent {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		f.setState(stateError)
 		return NewRequestError(resp.StatusCode)
 	}
@@ -483,6 +487,9 @@ func (f *Fetcher) Resolve(req *base.Request, opts *base.Options) error {
 	// For non-range resources, the response will be used directly in Start
 	if res.Range {
 		f.prefetchStopCh = make(chan struct{})
+		f.prefetchDoneCh = make(chan struct{})
+		f.prefetchDone.Store(false)
+		f.prefetchErr = nil
 		f.resolveFallback.Store(true)
 		go f.asyncPrefetch()
 	}
@@ -498,37 +505,35 @@ func (f *Fetcher) Resolve(req *base.Request, opts *base.Options) error {
 // asyncPrefetch downloads data in background during resolve phase
 // This data can be reused when Start is called to save time
 func (f *Fetcher) asyncPrefetch() {
-	defer func() {
-		f.prefetchDone.Store(true)
-	}()
-
 	// Get the resolve response
 	f.resolveRespLock.Lock()
 	resp := f.resolveResp
 	f.resolveRespLock.Unlock()
 
+	defer func() {
+		if resp != nil {
+			f.closeResolveResponseIfCurrent(resp)
+		}
+		f.prefetchDone.Store(true)
+		f.prefetchDoneOnce.Do(func() {
+			close(f.prefetchDoneCh)
+		})
+	}()
+
 	if resp == nil {
 		return
 	}
 
-	// Create temporary file for prefetch data
-	tmpFile, err := os.CreateTemp("", "gopeed-prefetch-*")
+	// POSIX unlinks the file immediately while retaining the open descriptor.
+	// Windows opens a file in a private directory with delete-on-close.
+	tmpFile, tmpPath, tmpDir, err := openPrefetchTempFile()
 	if err != nil {
 		f.prefetchErr = err
 		return
 	}
 	f.prefetchFile = tmpFile
-	f.prefetchFilePath = tmpFile.Name()
-
-	defer func() {
-		// Close response body when prefetch stops
-		f.resolveRespLock.Lock()
-		if f.resolveResp != nil {
-			f.resolveResp.Body.Close()
-			f.resolveResp = nil
-		}
-		f.resolveRespLock.Unlock()
-	}()
+	f.prefetchFilePath = tmpPath
+	f.prefetchDirPath = tmpDir
 
 	buf := make([]byte, 32*1024) // 32KB buffer
 	reader := NewTimeoutReader(resp.Body, readTimeout)
@@ -561,23 +566,61 @@ func (f *Fetcher) asyncPrefetch() {
 	}
 }
 
+// takeResolveResponse transfers ownership of the Resolve response to the
+// caller. Closing the body outside the lock is important because Close may
+// need to wake a concurrently blocked Read.
+func (f *Fetcher) takeResolveResponse() *http.Response {
+	f.resolveRespLock.Lock()
+	resp := f.resolveResp
+	f.resolveResp = nil
+	f.resolveRespLock.Unlock()
+	return resp
+}
+
+func (f *Fetcher) closeResolveResponse() {
+	if resp := f.takeResolveResponse(); resp != nil {
+		_ = resp.Body.Close()
+	}
+}
+
+// closeResolveResponseIfCurrent closes resp only if the Fetcher still owns
+// that exact response. Another path may already have taken ownership.
+func (f *Fetcher) closeResolveResponseIfCurrent(resp *http.Response) {
+	f.resolveRespLock.Lock()
+	owned := f.resolveResp == resp
+	if owned {
+		f.resolveResp = nil
+	}
+	f.resolveRespLock.Unlock()
+	if owned {
+		_ = resp.Body.Close()
+	}
+}
+
+// stopPrefetch is idempotent. Closing the response body is what interrupts a
+// Read that is blocked in the HTTP transport; closing the signal alone cannot
+// wake that Read.
+func (f *Fetcher) stopPrefetch() {
+	if f.prefetchStopCh == nil {
+		return
+	}
+	f.prefetchStopOnce.Do(func() {
+		close(f.prefetchStopCh)
+		f.closeResolveResponse()
+	})
+}
+
+func (f *Fetcher) waitPrefetch() {
+	if f.prefetchDoneCh != nil {
+		<-f.prefetchDoneCh
+	}
+}
+
 // stopPrefetchAndGetData stops the async prefetch and returns prefetched bytes
 // It also copies prefetched data to the target file
 func (f *Fetcher) stopPrefetchAndCopyData() int64 {
-	// Signal prefetch to stop (safely)
-	if f.prefetchStopCh != nil {
-		select {
-		case <-f.prefetchStopCh:
-			// Already closed
-		default:
-			close(f.prefetchStopCh)
-		}
-	}
-
-	// Wait for prefetch to finish (with timeout)
-	for i := 0; i < 1000 && !f.prefetchDone.Load(); i++ {
-		time.Sleep(10 * time.Millisecond)
-	}
+	f.stopPrefetch()
+	f.waitPrefetch()
 
 	prefetched := f.prefetchSize.Load()
 	if prefetched == 0 {
@@ -612,13 +655,12 @@ func (f *Fetcher) stopPrefetchAndCopyData() int64 {
 // cleanupPrefetchFile closes and removes the prefetch temporary file
 func (f *Fetcher) cleanupPrefetchFile() {
 	if f.prefetchFile != nil {
-		f.prefetchFile.Close()
+		_ = f.prefetchFile.Close()
 		f.prefetchFile = nil
 	}
-	if f.prefetchFilePath != "" {
-		os.Remove(f.prefetchFilePath)
-		f.prefetchFilePath = ""
-	}
+	cleanupPrefetchTempArtifacts(f.prefetchFilePath, f.prefetchDirPath)
+	f.prefetchFilePath = ""
+	f.prefetchDirPath = ""
 	// The byte count is only reusable while the backing prefetch file exists.
 	// Pause may discard that file before the first Start, so retaining the
 	// count would make the next Start skip bytes that were never copied.
@@ -728,12 +770,7 @@ func (f *Fetcher) doStart() error {
 
 		if !f.resolveFallback.Load() {
 			// Also close resolve response if still open.
-			f.resolveRespLock.Lock()
-			if f.resolveResp != nil {
-				f.resolveResp.Body.Close()
-				f.resolveResp = nil
-			}
-			f.resolveRespLock.Unlock()
+			f.closeResolveResponse()
 		}
 	}
 
@@ -1453,11 +1490,12 @@ func (f *Fetcher) completeFromResolveFallback(conn *connection) bool {
 		return false
 	}
 
-	for !f.prefetchDone.Load() {
-		if conn.ctx.Err() != nil {
+	if f.prefetchDoneCh != nil {
+		select {
+		case <-f.prefetchDoneCh:
+		case <-conn.ctx.Done():
 			return false
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
 	knownSize := f.meta.Res.Size > 0
 	if f.prefetchErr != nil || (knownSize && f.prefetchSize.Load() != f.meta.Res.Size) {
@@ -1674,10 +1712,7 @@ func (f *Fetcher) runConnectionWithResolveResp(conn *connection) {
 	buf := make([]byte, 8192)
 
 	// Get the resolve response
-	f.resolveRespLock.Lock()
-	resp := f.resolveResp
-	f.resolveResp = nil // Take ownership
-	f.resolveRespLock.Unlock()
+	resp := f.takeResolveResponse()
 
 	if resp == nil {
 		// No resolve response available, fall back to normal connection
@@ -2265,15 +2300,8 @@ func (f *Fetcher) Pause() error {
 		f.resolveCancel()
 	}
 
-	// Stop prefetch if running
-	if f.prefetchStopCh != nil {
-		select {
-		case <-f.prefetchStopCh:
-			// Already closed
-		default:
-			close(f.prefetchStopCh)
-		}
-	}
+	// Stop prefetch and close its response body to wake a blocked Read.
+	f.stopPrefetch()
 
 	// Wait for downloadLoop to exit first (it will call wg.Wait internally)
 	if f.downloadLoopDone != nil {
@@ -2283,10 +2311,8 @@ func (f *Fetcher) Pause() error {
 	// Wait for all connection goroutines to stop
 	f.wg.Wait()
 
-	// Wait for prefetch to finish
-	for f.prefetchStopCh != nil && !f.prefetchDone.Load() {
-		time.Sleep(10 * time.Millisecond)
-	}
+	// Wait until the prefetch goroutine has released the response completely.
+	f.waitPrefetch()
 
 	// If Pause wins before the first Range response is validated, materialize
 	// the Resolve prefix before discarding its temporary file. The first
@@ -2318,12 +2344,7 @@ func (f *Fetcher) Pause() error {
 	}
 
 	// Clean up resolve response if still held
-	f.resolveRespLock.Lock()
-	if f.resolveResp != nil {
-		f.resolveResp.Body.Close()
-		f.resolveResp = nil
-	}
-	f.resolveRespLock.Unlock()
+	f.closeResolveResponse()
 
 	f.fileMu.Lock()
 	if f.file != nil {

--- a/internal/protocol/http/prefetch_lifecycle_test.go
+++ b/internal/protocol/http/prefetch_lifecycle_test.go
@@ -1,0 +1,345 @@
+package http
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	gohttp "net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/GopeedLab/gopeed/pkg/base"
+	fhttp "github.com/GopeedLab/gopeed/pkg/protocol/http"
+)
+
+const (
+	prefetchProcessModeEnv  = "GOPEED_TEST_PREFETCH_PROCESS_MODE"
+	prefetchProcessReadyEnv = "GOPEED_TEST_PREFETCH_PROCESS_READY"
+)
+
+// processPrefetchBody first supplies actual data, then announces that the
+// prefetch file has been populated and blocks until Close interrupts it.
+type processPrefetchBody struct {
+	readyPath string
+	phase     atomic.Int32
+	readyOnce sync.Once
+	closeOnce sync.Once
+	readyCh   chan error
+	closedCh  chan struct{}
+}
+
+func newProcessPrefetchBody(readyPath string) *processPrefetchBody {
+	return &processPrefetchBody{
+		readyPath: readyPath,
+		readyCh:   make(chan error, 1),
+		closedCh:  make(chan struct{}),
+	}
+}
+
+func (b *processPrefetchBody) Read(p []byte) (int, error) {
+	if b.phase.CompareAndSwap(0, 1) {
+		for i := range p {
+			p[i] = byte(i % 251)
+		}
+		return len(p), nil
+	}
+
+	b.readyOnce.Do(func() {
+		err := os.WriteFile(b.readyPath, []byte("ready"), 0o600)
+		b.readyCh <- err
+		close(b.readyCh)
+	})
+	<-b.closedCh
+	return 0, io.EOF
+}
+
+func (b *processPrefetchBody) Close() error {
+	b.closeOnce.Do(func() {
+		close(b.closedCh)
+	})
+	return nil
+}
+
+// TestPrefetchTempProcessHelper is run in a subprocess by
+// TestPrefetchTempProcessExitLeavesNoNamedData. Do not run it directly.
+func TestPrefetchTempProcessHelper(t *testing.T) {
+	mode := os.Getenv(prefetchProcessModeEnv)
+	if mode == "" {
+		return
+	}
+
+	body := newProcessPrefetchBody(os.Getenv(prefetchProcessReadyEnv))
+	f := &Fetcher{
+		resolveResp:    &gohttp.Response{Body: body},
+		prefetchStopCh: make(chan struct{}),
+		prefetchDoneCh: make(chan struct{}),
+	}
+	go f.asyncPrefetch()
+
+	select {
+	case err := <-body.readyCh:
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+	case <-time.After(5 * time.Second):
+		fmt.Fprintln(os.Stderr, "prefetch helper did not populate its temporary file")
+		os.Exit(2)
+	}
+
+	switch mode {
+	case "cleanup":
+		f.stopPrefetch()
+		f.waitPrefetch()
+		f.cleanupPrefetchFile()
+		os.Exit(0)
+	case "exit":
+		// Deliberately omit Go cleanup. The operating system must reclaim the
+		// data when a process exits normally too.
+		os.Exit(0)
+	case "kill":
+		for {
+			time.Sleep(time.Hour)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown helper mode %q\n", mode)
+		os.Exit(2)
+	}
+}
+
+func TestPrefetchTempProcessExitLeavesNoNamedData(t *testing.T) {
+	for _, mode := range []string{"cleanup", "exit", "kill"} {
+		t.Run(mode, func(t *testing.T) {
+			baseDir := t.TempDir()
+			tempDir := filepath.Join(baseDir, "process-temp")
+			if err := os.Mkdir(tempDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			readyPath := filepath.Join(baseDir, "ready")
+
+			cmd := exec.Command(os.Args[0], "-test.run=^TestPrefetchTempProcessHelper$")
+			cmd.Env = isolatedProcessTempEnv(os.Environ(), tempDir)
+			cmd.Env = append(cmd.Env,
+				prefetchProcessModeEnv+"="+mode,
+				prefetchProcessReadyEnv+"="+readyPath,
+			)
+			var output bytes.Buffer
+			cmd.Stdout = &output
+			cmd.Stderr = &output
+			if err := cmd.Start(); err != nil {
+				t.Fatal(err)
+			}
+
+			waited := false
+			defer func() {
+				if !waited {
+					_ = cmd.Process.Kill()
+					_ = cmd.Wait()
+				}
+			}()
+
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				_, err := os.Stat(readyPath)
+				if err == nil {
+					break
+				}
+				if !errors.Is(err, os.ErrNotExist) {
+					t.Fatal(err)
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("timed out waiting for helper: %s", output.String())
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+
+			if mode == "kill" {
+				if err := cmd.Process.Kill(); err != nil {
+					t.Fatal(err)
+				}
+				// A killed child is expected to report a non-success exit status.
+				_ = cmd.Wait()
+				waited = true
+			} else {
+				if err := cmd.Wait(); err != nil {
+					t.Fatalf("helper failed: %v\n%s", err, output.String())
+				}
+				waited = true
+			}
+
+			paths, files, err := prefetchNamedResidues(tempDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(files) != 0 {
+				t.Fatalf("process exit left named prefetch data: %v", files)
+			}
+			if mode == "cleanup" && len(paths) != 0 {
+				t.Fatalf("normal cleanup left temporary artifacts: %v", paths)
+			}
+			if runtime.GOOS != "windows" && len(paths) != 0 {
+				t.Fatalf("POSIX process exit left directory entries: %v", paths)
+			}
+		})
+	}
+}
+
+func isolatedProcessTempEnv(env []string, tempDir string) []string {
+	filtered := make([]string, 0, len(env)+3)
+	for _, entry := range env {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.EqualFold(key, "TMPDIR") || strings.EqualFold(key, "TMP") || strings.EqualFold(key, "TEMP") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return append(filtered, "TMPDIR="+tempDir, "TMP="+tempDir, "TEMP="+tempDir)
+}
+
+func prefetchNamedResidues(tempDir string) (paths []string, files []string, err error) {
+	matches, err := filepath.Glob(filepath.Join(tempDir, "gopeed-prefetch-*"))
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, match := range matches {
+		err = filepath.WalkDir(match, func(path string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			rel, relErr := filepath.Rel(tempDir, path)
+			if relErr != nil {
+				return relErr
+			}
+			paths = append(paths, rel)
+			if !entry.IsDir() {
+				files = append(files, rel)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return paths, files, nil
+}
+
+type closeUnblocksReadBody struct {
+	startedOnce sync.Once
+	closedOnce  sync.Once
+	startedCh   chan struct{}
+	closedCh    chan struct{}
+}
+
+func newCloseUnblocksReadBody() *closeUnblocksReadBody {
+	return &closeUnblocksReadBody{
+		startedCh: make(chan struct{}),
+		closedCh:  make(chan struct{}),
+	}
+}
+
+func (b *closeUnblocksReadBody) Read([]byte) (int, error) {
+	b.startedOnce.Do(func() { close(b.startedCh) })
+	<-b.closedCh
+	return 0, io.EOF
+}
+
+func (b *closeUnblocksReadBody) Close() error {
+	b.closedOnce.Do(func() { close(b.closedCh) })
+	return nil
+}
+
+func TestFetcherCloseInterruptsBlockedPrefetchRead(t *testing.T) {
+	body := newCloseUnblocksReadBody()
+	f := &Fetcher{
+		resolveResp:    &gohttp.Response{Body: body},
+		prefetchStopCh: make(chan struct{}),
+		prefetchDoneCh: make(chan struct{}),
+	}
+	go f.asyncPrefetch()
+
+	select {
+	case <-body.startedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetch never entered the blocking Read")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- f.Close() }()
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not interrupt the blocked prefetch Read")
+	}
+
+	select {
+	case <-f.prefetchDoneCh:
+	default:
+		t.Fatal("Close returned before the prefetch goroutine exited")
+	}
+	if f.prefetchFile != nil || f.prefetchFilePath != "" || f.prefetchDirPath != "" {
+		t.Fatal("Close returned before cleaning prefetch temporary artifacts")
+	}
+}
+
+func TestFetcherCompletedPrefetchStillFeedsDownload(t *testing.T) {
+	payload := make([]byte, 256*1024+137)
+	for i := range payload {
+		payload[i] = byte((i*31 + 7) % 251)
+	}
+	server := httptest.NewServer(gohttp.HandlerFunc(func(w gohttp.ResponseWriter, r *gohttp.Request) {
+		gohttp.ServeContent(w, r, "source.bin", time.Unix(1, 0), bytes.NewReader(payload))
+	}))
+	defer server.Close()
+
+	f := buildFetcher()
+	t.Cleanup(func() { _ = f.Close() })
+	outputDir := t.TempDir()
+	if err := f.Resolve(&base.Request{URL: server.URL + "/source.bin"}, &base.Options{
+		Path: outputDir,
+		Name: "prefetch-output.bin",
+		Extra: &fhttp.OptsExtra{
+			Connections: 2,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-f.prefetchDoneCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for completed prefetch")
+	}
+	if f.prefetchErr != nil {
+		t.Fatalf("prefetch failed: %v", f.prefetchErr)
+	}
+
+	if err := f.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(outputDir, "prefetch-output.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("downloaded data differs after consuming completed prefetch: got %d bytes, want %d", len(got), len(payload))
+	}
+	if f.prefetchFile != nil || f.prefetchFilePath != "" || f.prefetchDirPath != "" {
+		t.Fatal("completed download retained prefetch temporary artifacts")
+	}
+}

--- a/internal/protocol/http/prefetch_temp_nonwindows.go
+++ b/internal/protocol/http/prefetch_temp_nonwindows.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package http
+
+import (
+	"fmt"
+	"os"
+)
+
+// openPrefetchTempFile creates an anonymous-on-crash prefetch file. POSIX
+// keeps the open file description valid after unlink while removing the only
+// directory entry, so the kernel reclaims the data even if the process dies.
+func openPrefetchTempFile() (*os.File, string, string, error) {
+	file, err := os.CreateTemp("", "gopeed-prefetch-*")
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	filePath := file.Name()
+	if err := os.Remove(filePath); err != nil {
+		_ = file.Close()
+		_ = os.Remove(filePath)
+		return nil, "", "", fmt.Errorf("unlink prefetch temporary file: %w", err)
+	}
+	return file, filePath, "", nil
+}
+
+func cleanupPrefetchTempArtifacts(filePath, _ string) {
+	// Normally the path was unlinked at creation. Retrying removal also covers
+	// unusual filesystems where the first unlink raced with external activity.
+	if filePath != "" {
+		_ = os.Remove(filePath)
+	}
+}

--- a/internal/protocol/http/prefetch_temp_windows.go
+++ b/internal/protocol/http/prefetch_temp_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package http
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// Windows cannot unlink an ordinary open file. Put it in a private directory
+// and ask the kernel to delete the data file whenever its last handle closes,
+// including process termination. A killed process may leave only an empty,
+// negligible directory; normal cleanup removes that directory too.
+func openPrefetchTempFile() (*os.File, string, string, error) {
+	dirPath, err := os.MkdirTemp("", "gopeed-prefetch-*")
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	filePath := filepath.Join(dirPath, "data")
+	file, err := os.OpenFile(
+		filePath,
+		os.O_RDWR|os.O_CREATE|os.O_EXCL|windows.O_FILE_FLAG_DELETE_ON_CLOSE,
+		0o600,
+	)
+	if err != nil {
+		_ = os.Remove(dirPath)
+		return nil, "", "", err
+	}
+	return file, filePath, dirPath, nil
+}
+
+func cleanupPrefetchTempArtifacts(filePath, dirPath string) {
+	// Close should already have triggered delete-on-close. Explicit removal is
+	// harmless and covers filesystems that defer the deletion briefly.
+	if filePath != "" {
+		_ = os.Remove(filePath)
+	}
+	if dirPath != "" {
+		_ = os.Remove(dirPath)
+	}
+}

--- a/pkg/download/downloader.go
+++ b/pkg/download/downloader.go
@@ -45,6 +45,7 @@ const (
 var (
 	ErrTaskNotFound        = errors.New("task not found")
 	ErrUnSupportedProtocol = errors.New("unsupported protocol")
+	ErrDownloaderClosed    = errors.New("downloader is closed")
 )
 
 type Listener func(event *Event)
@@ -106,6 +107,9 @@ type Downloader struct {
 	fetcherMapLock     *sync.RWMutex
 	checkDuplicateLock *sync.Mutex
 	closed             atomic.Bool
+	lifecycleWG        sync.WaitGroup
+	closeOnce          sync.Once
+	closeErr           error
 
 	// claimedExtractions tracks which multi-part archives have been claimed for extraction
 	// Key: fullBaseName (e.g., "/path/archive.7z"), Value: taskID that claimed it
@@ -222,7 +226,7 @@ func (d *Downloader) Setup() error {
 
 	// handle upload
 	go func() {
-		for _, task := range d.tasks {
+		for _, task := range d.snapshotTasks() {
 			if task.Status == base.DownloadStatusDone && task.Uploading {
 				if err := d.restoreTask(task); err != nil {
 					d.Logger.Error().Stack().Err(err).Msgf("task upload restore fetcher failed, task id: %s", task.ID)
@@ -239,8 +243,9 @@ func (d *Downloader) Setup() error {
 	// calculate download speed every tick
 	go func() {
 		for !d.closed.Load() {
-			if len(d.tasks) > 0 {
-				for _, task := range d.tasks {
+			tasks := d.snapshotTasks()
+			if len(tasks) > 0 {
+				for _, task := range tasks {
 					func() {
 						// Do not acquire d.lock (via GetTask) while holding
 						// statusLock; scheduling uses the opposite lock order.
@@ -426,9 +431,13 @@ func ensureResourceRequestRawURLs(parentReq *base.Request, res *base.Resource) {
 }
 
 func (d *Downloader) Resolve(req *base.Request, opts *base.Options) (rr *ResolveResult, err error) {
+	if d.closed.Load() {
+		return nil, ErrDownloaderClosed
+	}
+
 	rrId, err := gonanoid.New()
 	if err != nil {
-		return
+		return nil, err
 	}
 	ensureRequestRawURL(req)
 
@@ -449,13 +458,17 @@ func (d *Downloader) Resolve(req *base.Request, opts *base.Options) (rr *Resolve
 	}
 	initOpt, err := d.initOptions(opts)
 	if err != nil {
-		return
+		return nil, err
 	}
 	err = fetcher.Resolve(req, initOpt)
 	if err != nil {
-		return
+		return nil, err
 	}
 	d.fetcherMapLock.Lock()
+	if d.closed.Load() {
+		d.fetcherMapLock.Unlock()
+		return nil, errors.Join(ErrDownloaderClosed, fetcher.Close())
+	}
 	d.fetcherCache[rrId] = fetcher
 	d.fetcherMapLock.Unlock()
 	rr = &ResolveResult{
@@ -493,6 +506,11 @@ func (d *Downloader) remainRunningCount() int {
 }
 
 func (d *Downloader) CreateDirect(req *base.Request, opts *base.Options) (taskId string, err error) {
+	if err = d.beginLifecycleOperation(); err != nil {
+		return "", err
+	}
+	defer d.lifecycleWG.Done()
+
 	ensureRequestRawURL(req)
 	var fetcher fetcher.Fetcher
 	fetcher, err = d.buildFetcher(req.URL)
@@ -502,7 +520,7 @@ func (d *Downloader) CreateDirect(req *base.Request, opts *base.Options) (taskId
 	fetcher.Meta().Req = req
 	initOpt, err := d.initOptions(opts)
 	if err != nil {
-		return
+		return "", err
 	}
 	return d.doCreate(fetcher, initOpt)
 }
@@ -524,18 +542,83 @@ func (d *Downloader) CreateDirectBatch(req *base.CreateTaskBatch) (taskId []stri
 }
 
 func (d *Downloader) Create(rrId string) (taskId string, err error) {
-	d.fetcherMapLock.RLock()
-	fetcher, ok := d.fetcherCache[rrId]
-	d.fetcherMapLock.RUnlock()
+	if err = d.beginLifecycleOperation(); err != nil {
+		return "", err
+	}
+	defer d.lifecycleWG.Done()
+
+	fetcher, ok := d.takeResolveFetcher(rrId)
 	if !ok {
 		return "", errors.New("invalid resource id")
 	}
-	defer func() {
-		d.fetcherMapLock.Lock()
+	taskId, err = d.doCreate(fetcher, nil)
+	if err != nil {
+		err = errors.Join(err, fetcher.Close())
+	}
+	return taskId, err
+}
+
+// CancelResolve releases a resolved fetcher that will not be used to create a
+// task. It is intentionally idempotent so clients can call it from cleanup
+// paths even when Create has already consumed the resolve result.
+func (d *Downloader) CancelResolve(rrId string) error {
+	if err := d.beginLifecycleOperation(); err != nil {
+		// Close has already claimed every cached resolve. Cancellation remains
+		// an idempotent cleanup operation even while the downloader shuts down.
+		if errors.Is(err, ErrDownloaderClosed) {
+			return nil
+		}
+		return err
+	}
+	defer d.lifecycleWG.Done()
+
+	fetcher, ok := d.takeResolveFetcher(rrId)
+	if !ok {
+		return nil
+	}
+	return fetcher.Close()
+}
+
+// beginLifecycleOperation linearizes public fetcher ownership operations with
+// Close. Close sets closed while holding the same lock, so no WaitGroup Add can
+// race with its Wait.
+func (d *Downloader) beginLifecycleOperation() error {
+	d.fetcherMapLock.Lock()
+	defer d.fetcherMapLock.Unlock()
+	if d.closed.Load() {
+		return ErrDownloaderClosed
+	}
+	d.lifecycleWG.Add(1)
+	return nil
+}
+
+func (d *Downloader) takeResolveFetcher(rrId string) (fetcher.Fetcher, bool) {
+	d.fetcherMapLock.Lock()
+	defer d.fetcherMapLock.Unlock()
+
+	f, ok := d.fetcherCache[rrId]
+	if ok {
 		delete(d.fetcherCache, rrId)
-		d.fetcherMapLock.Unlock()
-	}()
-	return d.doCreate(fetcher, nil)
+	}
+	return f, ok
+}
+
+func (d *Downloader) takeResolveFetchersForClose() []fetcher.Fetcher {
+	d.fetcherMapLock.Lock()
+	d.closed.Store(true)
+
+	cache := d.fetcherCache
+	d.fetcherCache = make(map[string]fetcher.Fetcher)
+	d.fetcherMapLock.Unlock()
+
+	fetchers := make([]fetcher.Fetcher, 0, len(cache))
+	for _, f := range cache {
+		if f == nil {
+			continue
+		}
+		fetchers = append(fetchers, f)
+	}
+	return fetchers
 }
 
 // Patch modifies task-specific data based on the protocol.
@@ -864,27 +947,42 @@ func (d *Downloader) doDelete(task *Task, force bool) (err error) {
 }
 
 func (d *Downloader) Close() error {
-	d.closed.Store(true)
-
-	closeArr := []func() error{
-		d.pauseAll,
-	}
-	for _, fm := range d.cfg.FetchManagers {
-		closeArr = append(closeArr, fm.Close)
-	}
-	if d.blob != nil {
-		closeArr = append(closeArr, d.blob.Close)
-	}
-	closeArr = append(closeArr, d.storage.Close)
-	// Make sure all resources are released, if had error, return the last error
-	var lastErr error
-	for i, close := range closeArr {
-		if err := close(); err != nil {
-			lastErr = err
-			d.Logger.Error().Stack().Err(err).Msgf("downloader close failed, index: %d", i)
+	d.closeOnce.Do(func() {
+		var errs []error
+		for _, f := range d.takeResolveFetchersForClose() {
+			if err := f.Close(); err != nil {
+				errs = append(errs, err)
+			}
 		}
-	}
-	return lastErr
+
+		// Create and cancellation operations that started before Close finish
+		// their ownership transfer before managers and storage are closed. No
+		// new operation can join the WaitGroup after this wait begins.
+		d.lifecycleWG.Wait()
+
+		closeArr := []func() error{d.pauseAll}
+		for _, fm := range d.cfg.FetchManagers {
+			closeArr = append(closeArr, fm.Close)
+		}
+		if d.blob != nil {
+			closeArr = append(closeArr, d.blob.Close)
+		}
+		closeArr = append(closeArr, d.storage.Close)
+		for i, close := range closeArr {
+			if err := close(); err != nil {
+				errs = append(errs, err)
+				d.Logger.Error().Stack().Err(err).Msgf("downloader close failed, index: %d", i)
+			}
+		}
+		d.closeErr = errors.Join(errs...)
+	})
+	return d.closeErr
+}
+
+func (d *Downloader) snapshotTasks() []*Task {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return append([]*Task(nil), d.tasks...)
 }
 
 func (d *Downloader) Clear() error {
@@ -893,7 +991,10 @@ func (d *Downloader) Clear() error {
 			return err
 		}
 	}
+	d.lock.Lock()
 	d.tasks = make([]*Task, 0)
+	d.waitTasks = make([]*Task, 0)
+	d.lock.Unlock()
 	d.extensions = make([]*Extension, 0)
 	if err := d.storage.Clear(); err != nil {
 		return err

--- a/pkg/download/downloader_test.go
+++ b/pkg/download/downloader_test.go
@@ -32,9 +32,11 @@ import (
 type generationTestManager struct {
 	starts         atomic.Int32
 	pauses         atomic.Int32
+	closes         atomic.Int32
 	holdOpen       bool
+	closeErr       error
 	resolveStarted chan struct{}
-	resolveRelease <-chan struct{}
+	resolveRelease chan struct{}
 	resolveErr     error
 	resolveOnce    sync.Once
 	pauseStarted   chan struct{}
@@ -151,7 +153,10 @@ func (f *generationTestFetcher) Pause() error {
 	}
 	return nil
 }
-func (f *generationTestFetcher) Close() error               { return nil }
+func (f *generationTestFetcher) Close() error {
+	f.manager.closes.Add(1)
+	return f.manager.closeErr
+}
 func (f *generationTestFetcher) Stats() any                 { return nil }
 func (f *generationTestFetcher) Meta() *fetcher.FetcherMeta { return f.meta }
 func (f *generationTestFetcher) Progress() fetcher.Progress { return fetcher.Progress{1} }
@@ -203,6 +208,165 @@ func TestDownloader_Resolve(t *testing.T) {
 	}
 	if !test.AssertResourceEqual(want, rr.Res) {
 		t.Errorf("Resolve() got = %v, want %v", rr.Res, want)
+	}
+}
+
+func TestDownloader_CancelResolveClosesCachedFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	downloader := NewDownloader(&DownloaderConfig{FetchManagers: []fetcher.FetcherManager{manager}})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	defer downloader.Clear()
+
+	rr, err := downloader.Resolve(
+		&base.Request{URL: "generation://cancel"},
+		&base.Options{Path: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := downloader.CancelResolve(rr.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.closes.Load(); got != 1 {
+		t.Fatalf("Close calls = %d, want 1", got)
+	}
+	if len(downloader.fetcherCache) != 0 {
+		t.Fatalf("cached fetchers = %d, want 0", len(downloader.fetcherCache))
+	}
+
+	// Cleanup code may run after Create has consumed the ID, so cancellation is
+	// deliberately idempotent.
+	if err := downloader.CancelResolve(rr.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.closes.Load(); got != 1 {
+		t.Fatalf("Close calls after repeated cancel = %d, want 1", got)
+	}
+}
+
+func TestDownloader_CloseClosesAllCachedFetchers(t *testing.T) {
+	manager := &generationTestManager{closeErr: errors.New("close failed")}
+	downloader := NewDownloader(&DownloaderConfig{FetchManagers: []fetcher.FetcherManager{manager}})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"first", "second", "third"} {
+		if _, err := downloader.Resolve(
+			&base.Request{URL: "generation://" + name},
+			&base.Options{Path: t.TempDir()},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := downloader.Close(); !errors.Is(err, manager.closeErr) {
+		t.Fatalf("Close error = %v, want %v", err, manager.closeErr)
+	}
+	if got := manager.closes.Load(); got != 3 {
+		t.Fatalf("Close calls = %d, want 3", got)
+	}
+	if len(downloader.fetcherCache) != 0 {
+		t.Fatalf("cached fetchers = %d, want 0", len(downloader.fetcherCache))
+	}
+}
+
+func TestDownloader_ResolveAfterCloseDoesNotBuildFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	downloader := NewDownloader(&DownloaderConfig{FetchManagers: []fetcher.FetcherManager{manager}})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloader.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := downloader.Resolve(
+		&base.Request{URL: "generation://closed"},
+		&base.Options{Path: t.TempDir()},
+	)
+	if err == nil {
+		t.Fatal("Resolve after Close succeeded")
+	}
+	if got := manager.closes.Load(); got != 0 {
+		t.Fatalf("Close calls = %d, want 0 because no fetcher should be built", got)
+	}
+	if len(downloader.fetcherCache) != 0 {
+		t.Fatalf("cached fetchers = %d, want 0", len(downloader.fetcherCache))
+	}
+}
+
+func TestDownloader_CloseWaitsForCreateThatAlreadyOwnsFetcher(t *testing.T) {
+	manager := &generationTestManager{}
+	downloader := NewDownloader(&DownloaderConfig{FetchManagers: []fetcher.FetcherManager{manager}})
+	if err := downloader.Setup(); err != nil {
+		t.Fatal(err)
+	}
+	downloader.cfg.MaxRunning = 0
+
+	rr, err := downloader.Resolve(
+		&base.Request{URL: "generation://create-close-race"},
+		&base.Options{Path: t.TempDir()},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold the task-list lock after Create has taken ownership from the resolve
+	// cache. Close must wait for that in-flight ownership transfer.
+	downloader.lock.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			downloader.lock.Unlock()
+		}
+	}()
+	createDone := make(chan error, 1)
+	go func() {
+		_, err := downloader.Create(rr.ID)
+		createDone <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		downloader.fetcherMapLock.RLock()
+		_, cached := downloader.fetcherCache[rr.ID]
+		downloader.fetcherMapLock.RUnlock()
+		if !cached {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Create did not take ownership of the cached fetcher")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- downloader.Close() }()
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before in-flight Create completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	downloader.lock.Unlock()
+	locked = false
+	select {
+	case err := <-createDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Create did not complete")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not finish after Create transferred ownership")
 	}
 }
 

--- a/pkg/rest/api.go
+++ b/pkg/rest/api.go
@@ -35,6 +35,19 @@ func Resolve(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func CancelResolve(w http.ResponseWriter, r *http.Request) {
+	resolveID := mux.Vars(r)["id"]
+	if resolveID == "" {
+		WriteJson(w, model.NewErrorResult("param invalid: id", model.CodeInvalidParam))
+		return
+	}
+	if err := Downloader.CancelResolve(resolveID); err != nil {
+		WriteJson(w, model.NewErrorResult(err.Error()))
+		return
+	}
+	WriteJson(w, model.NewNilResult())
+}
+
 func CreateTask(w http.ResponseWriter, r *http.Request) {
 	var req model.CreateTask
 	if ReadJson(r, w, &req) {

--- a/pkg/rest/server.go
+++ b/pkg/rest/server.go
@@ -122,6 +122,7 @@ func BuildServer(startCfg *model.StartConfig) (*http.Server, net.Listener, error
 	var r = mux.NewRouter()
 	r.Methods(http.MethodGet).Path("/api/v1/info").HandlerFunc(Info)
 	r.Methods(http.MethodPost).Path("/api/v1/resolve").HandlerFunc(Resolve)
+	r.Methods(http.MethodDelete).Path("/api/v1/resolve/{id}").HandlerFunc(CancelResolve)
 	r.Methods(http.MethodPost).Path("/api/v1/tasks").HandlerFunc(CreateTask)
 	r.Methods(http.MethodPost).Path("/api/v1/tasks/batch").HandlerFunc(CreateTaskBatch)
 	r.Methods(http.MethodPatch).Path("/api/v1/tasks/{id}").HandlerFunc(PatchTask)

--- a/pkg/rest/server_test.go
+++ b/pkg/rest/server_test.go
@@ -92,6 +92,19 @@ func TestResolve(t *testing.T) {
 	})
 }
 
+func TestCancelResolve(t *testing.T) {
+	doTest(func() {
+		resp := httpRequestCheckOk[*download.ResolveResult](http.MethodPost, "/api/v1/resolve", resolveReq)
+		if resp.ID == "" {
+			t.Fatal("Resolve() returned an empty ID")
+		}
+		httpRequestCheckOk[any](http.MethodDelete, "/api/v1/resolve/"+resp.ID, nil)
+		// Cancellation is idempotent so callers can always release in a finally
+		// block, even if Create has already consumed the resolve result.
+		httpRequestCheckOk[any](http.MethodDelete, "/api/v1/resolve/"+resp.ID, nil)
+	})
+}
+
 func TestCreateTask(t *testing.T) {
 	doTest(func() {
 		resp := httpRequestCheckOk[*download.ResolveResult](http.MethodPost, "/api/v1/resolve", resolveReq)

--- a/ui/flutter/lib/api/api.dart
+++ b/ui/flutter/lib/api/api.dart
@@ -140,6 +140,11 @@ Future<ResolveResult> resolve(ResolveTask resolveTask) async {
       (data) => ResolveResult.fromJson(data));
 }
 
+Future<void> cancelResolve(String id) async {
+  if (id.isEmpty) return;
+  await _parse(() => _client.dio.delete("api/v1/resolve/$id"), null);
+}
+
 Future<String> createTask(CreateTask createTask) async {
   final result = await _parse<String>(
       () => _client.dio.post("api/v1/tasks", data: createTask),

--- a/ui/flutter/lib/app/modules/create/views/create_dialog_view.dart
+++ b/ui/flutter/lib/app/modules/create/views/create_dialog_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get.dart';
@@ -29,6 +31,7 @@ class _CreateDialogViewState extends State<CreateDialogView> {
   Object? _error;
   bool _resolving = true;
   bool _creating = false;
+  bool _closing = false;
 
   @override
   void initState() {
@@ -42,6 +45,10 @@ class _CreateDialogViewState extends State<CreateDialogView> {
 
   @override
   void dispose() {
+    final resolveID = _resolveResult?.id ?? '';
+    if (resolveID.isNotEmpty) {
+      unawaited(cancelResolve(resolveID).catchError((_) {}));
+    }
     _pathController.dispose();
     _nameController.dispose();
     super.dispose();
@@ -87,7 +94,10 @@ class _CreateDialogViewState extends State<CreateDialogView> {
       final result = await resolve(
         ResolveTask(req: createTask.req!, opts: opt),
       );
-      if (!mounted) return;
+      if (!mounted || _closing) {
+        await cancelResolve(result.id);
+        return;
+      }
       setState(() {
         _resolveResult = result;
         if (_nameController.text.trim().isEmpty ||
@@ -160,6 +170,8 @@ class _CreateDialogViewState extends State<CreateDialogView> {
           ),
         );
       }
+      // A successful Create has consumed the resolve ID server-side.
+      _resolveResult = null;
       await SystemNavigator.pop();
     } catch (e) {
       showErrorMessage(e);
@@ -168,6 +180,26 @@ class _CreateDialogViewState extends State<CreateDialogView> {
           _creating = false;
         });
       }
+    }
+  }
+
+  Future<void> _cancelAndClose() async {
+    if (_closing) return;
+    setState(() {
+      _closing = true;
+    });
+
+    final resolveResult = _resolveResult;
+    _resolveResult = null;
+    try {
+      if (resolveResult?.id.isNotEmpty == true) {
+        await cancelResolve(resolveResult!.id);
+      }
+    } catch (_) {
+      // Downloader shutdown is the final cleanup fallback. A failed cleanup
+      // request must not trap the user in the quick-create window.
+    } finally {
+      await SystemNavigator.pop();
     }
   }
 
@@ -227,7 +259,8 @@ class _CreateDialogViewState extends State<CreateDialogView> {
                         ),
                         IconButton(
                           icon: const Icon(Icons.close),
-                          onPressed: _creating ? null : SystemNavigator.pop,
+                          onPressed:
+                              (_creating || _closing) ? null : _cancelAndClose,
                           tooltip: 'cancel'.tr,
                         ),
                       ],
@@ -269,7 +302,8 @@ class _CreateDialogViewState extends State<CreateDialogView> {
                       mainAxisAlignment: MainAxisAlignment.end,
                       children: [
                         TextButton(
-                          onPressed: _creating ? null : SystemNavigator.pop,
+                          onPressed:
+                              (_creating || _closing) ? null : _cancelAndClose,
                           child: Text('cancel'.tr),
                         ),
                         const SizedBox(width: 8),

--- a/ui/flutter/lib/app/modules/create/views/create_view.dart
+++ b/ui/flutter/lib/app/modules/create/views/create_view.dart
@@ -1039,7 +1039,8 @@ class CreateView extends GetView<CreateController> {
   Future<void> _showResolveDialog(ResolveResult rr) async {
     final createFormKey = GlobalKey<FormState>();
     final downloadController = RoundedLoadingButtonController();
-    return showDialog<void>(
+    try {
+      await showDialog<void>(
         context: Get.context!,
         barrierDismissible: false,
         builder: (_) => AlertDialog(
@@ -1144,6 +1145,16 @@ class CreateView extends GetView<CreateController> {
                 ),
               ],
             ));
+    } finally {
+      // Create consumes the resolve ID. If the dialog was cancelled or failed,
+      // this idempotent call releases the still-cached fetcher instead.
+      try {
+        await cancelResolve(rr.id);
+      } catch (_) {
+        // Cleanup failure must not replace a successful create/navigation
+        // result. Downloader shutdown remains the final cleanup fallback.
+      }
+    }
   }
 
   Widget _buildCategorySelector(AppController appController) {


### PR DESCRIPTION
Fixes #1469.

## Summary

- Store HTTP Resolve prefetch data in crash-safe temporary storage:
  - POSIX unlinks the file immediately after opening it.
  - Windows uses a private temporary directory and `FILE_FLAG_DELETE_ON_CLOSE`.
- Replace polling-based prefetch shutdown with a deterministic completion signal. Closing a fetcher's response body now interrupts a blocked read, and cleanup waits for the prefetch goroutine to exit.
- Add an idempotent `DELETE /api/v1/resolve/{id}` operation so clients can release abandoned Resolve results.
- Make the Flutter create flows release unused Resolve results, and drain the full Resolve cache during downloader shutdown.
- Linearize Create/Cancel/Close ownership transfers and aggregate shutdown errors instead of silently losing earlier failures.
- Add lifecycle, process-exit, forced-termination, blocked-read, content-correctness, REST, and shutdown regression tests.

## Behavior and scope

This fixes named orphan files after both normal cleanup and abrupt process termination, and gives completed-but-abandoned Resolve results an explicit lifecycle.

It deliberately does not impose a live-process TTL or byte cap. Prefetch can still stage a full response while Gopeed is running because it preserves one-time URL fallback behavior. A future budget/backpressure policy needs a separate design rather than silently truncating that fallback.

Draft #1451 overlaps with draining cached Resolve results, but this PR is narrowly focused on the prefetch lifecycle and crash-safe backing storage.

## Verification

- The deterministic baseline reproduction from #1469 no longer leaves a named `gopeed-prefetch-*` data file.
- Focused HTTP/downloader/REST lifecycle tests pass.
- The same focused suite passes with the Go race detector.
- The complete HTTP package passes with the race detector.
- The HTTP package cross-compiles for Windows amd64.

Flutter tooling was not available in the local environment, so the Dart changes rely on repository CI for analyzer/build coverage.
