### PR TITLE
fix(flutter): create log directory recursively

### DIFF
--- a/ui/flutter/lib/util/log_util.dart
+++ b/ui/flutter/lib/util/log_util.dart
@@ -19,14 +19,15 @@ String logsDir() {
   return path.join(Util.getStorageDir(), 'logs');
 }
 
+Directory ensureLogDirectory(String logDirPath) {
+  return Directory(logDirPath)..createSync(recursive: true);
+}
+
 LogOutput? _buildOutput() {
   // if is debug mode, don't log to file
   if (!kDebugMode && Util.isDesktop()) {
     final logDirPath = logsDir();
-    var logDir = Directory(logsDir());
-    if (!logDir.existsSync()) {
-      logDir.createSync();
-    }
+    ensureLogDirectory(logDirPath);
     return FileOutput(file: File('$logDirPath/client.log'));
   }
   return null;

--- a/ui/flutter/test/log_util_test.dart
+++ b/ui/flutter/test/log_util_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gopeed/util/log_util.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() async {
+    temporaryDirectory = await Directory.systemTemp.createTemp('gopeed-log-util-');
+  });
+
+  tearDown(() async {
+    await temporaryDirectory.delete(recursive: true);
+  });
+
+  test('creates the log directory when its parents do not exist', () {
+    final logDirPath = path.join(temporaryDirectory.path, 'storage', 'logs');
+
+    final logDirectory = ensureLogDirectory(logDirPath);
+
+    expect(logDirectory.path, logDirPath);
+    expect(logDirectory.existsSync(), isTrue);
+  });
+
+  test('allows the log directory to be initialized repeatedly', () {
+    final logDirPath = path.join(temporaryDirectory.path, 'storage', 'logs');
+
+    ensureLogDirectory(logDirPath);
+    final logDirectory = ensureLogDirectory(logDirPath);
+
+    expect(logDirectory.existsSync(), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary

- create the Flutter client log directory recursively before opening `client.log`
- make repeated log initialization safe
- add regression coverage for a missing parent `storage` directory

## Root cause

The new startup flow initializes the Flutter logger before the Go runtime. The Go backend normally creates `storage`, but Flutter attempted to create `storage/logs` non-recursively first. On installations where `storage` did not already exist, Windows raised `PathNotFoundException` and the app could not start.

## Testing

- `flutter analyze`
- `flutter test test/log_util_test.dart`
