### PR TITLE
fix: unify platform window titles as Gopeed

### DIFF
--- a/ui/flutter/lib/app/app.dart
+++ b/ui/flutter/lib/app/app.dart
@@ -79,7 +79,7 @@ class _GopeedAppState extends ConsumerState<GopeedApp> with WidgetsBindingObserv
     return shad.ShadcnApp.router(
       debugShowCheckedModeBanner: false,
       disableBrowserContextMenu: false,
-      onGenerateTitle: (context) => context.l10n.appTitle,
+      title: 'Gopeed',
       theme: AppTheme.light(themeColor),
       darkTheme: AppTheme.dark(themeColor),
       materialTheme: isLightTheme ? AppTheme.materialLight(themeColor) : AppTheme.materialDark(themeColor),

--- a/ui/flutter/lib/core/window/app_window_bootstrap.dart
+++ b/ui/flutter/lib/core/window/app_window_bootstrap.dart
@@ -16,6 +16,7 @@ class AppWindowBootstrap {
     await windowManager.ensureInitialized();
 
     final windowOptions = WindowOptions(
+      title: 'Gopeed',
       size: const Size(1024, 768),
       center: true,
       skipTaskbar: false,
@@ -74,8 +75,8 @@ class AppWindowBootstrap {
 
   static String subWindowTitle(AppWindowType type, AppLocalizations l10n) {
     return switch (type) {
-      AppWindowType.createTask => '${l10n.create} - Gopeed',
-      _ => l10n.appTitle,
+      AppWindowType.createTask => 'Gopeed-${l10n.create}',
+      _ => 'Gopeed',
     };
   }
 

--- a/ui/flutter/lib/core/window/app_window_bootstrap.dart
+++ b/ui/flutter/lib/core/window/app_window_bootstrap.dart
@@ -75,7 +75,7 @@ class AppWindowBootstrap {
 
   static String subWindowTitle(AppWindowType type, AppLocalizations l10n) {
     return switch (type) {
-      AppWindowType.createTask => 'Gopeed-${l10n.create}',
+      AppWindowType.createTask => 'Gopeed - ${l10n.create}',
       _ => 'Gopeed',
     };
   }

--- a/ui/flutter/linux/runner/my_application.cc
+++ b/ui/flutter/linux/runner/my_application.cc
@@ -48,11 +48,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "gopeed");
+    gtk_header_bar_set_title(header_bar, "Gopeed");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "gopeed");
+    gtk_window_set_title(window, "Gopeed");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/ui/flutter/macos/Runner/Base.lproj/MainMenu.xib
+++ b/ui/flutter/macos/Runner/Base.lproj/MainMenu.xib
@@ -330,7 +330,7 @@
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>
-        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
+        <window title="Gopeed" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1577"/>

--- a/ui/flutter/test/core/window/app_window_payload_test.dart
+++ b/ui/flutter/test/core/window/app_window_payload_test.dart
@@ -9,9 +9,9 @@ void main() {
   test('create-task child window has a localized native title', () {
     expect(
       AppWindowBootstrap.subWindowTitle(AppWindowType.createTask, appLocalizationsFor('en')),
-      'Create Task - Gopeed',
+      'Gopeed-Create Task',
     );
-    expect(AppWindowBootstrap.subWindowTitle(AppWindowType.createTask, appLocalizationsFor('zh')), '创建任务 - Gopeed');
+    expect(AppWindowBootstrap.subWindowTitle(AppWindowType.createTask, appLocalizationsFor('zh')), 'Gopeed-创建任务');
   });
 
   test('create-task payload only carries initial task data', () {

--- a/ui/flutter/web/manifest.json
+++ b/ui/flutter/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "gopeed",
-    "short_name": "gopeed",
+    "name": "Gopeed",
+    "short_name": "Gopeed",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/ui/flutter/windows/runner/main.cpp
+++ b/ui/flutter/windows/runner/main.cpp
@@ -56,7 +56,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   flutter::DartProject project(L"data");
   std::vector<std::string> command_line_arguments = GetCommandLineArguments();
   if (!IsMultiWindowLaunch(command_line_arguments) &&
-      SendAppLinkToInstance(L"gopeed")) {
+      SendAppLinkToInstance(L"Gopeed")) {
     return EXIT_SUCCESS;
   }
 
@@ -71,7 +71,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"gopeed", origin, size)) {
+  if (!window.Create(L"Gopeed", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
Window titles currently mix lowercase gopeed, localized descriptions such as Gopeed Download Manager, and feature-first child window titles.

Use Gopeed for the main application title across platforms, including Android recent apps and the web tab. Set the desktop main window title explicitly, align Windows/Linux/macOS startup titles and the web app manifest, and update both Windows window creation and existing-instance lookup to Gopeed. Executable names and installation/storage paths remain unchanged.

Use Gopeed-<localized Create Task> for desktop create-task windows: Gopeed-创建任务 in Chinese and Gopeed-Create Task in English, reusing the existing translations.

Validation:
- Flutter analysis, localization catalog check/generation, formatting, and git diff --check passed.
- Full Flutter suite: 198 passed, 1 skipped, 1 failed. The failure expects 21 supported languages but finds 22; reproduced on the unmodified main baseline.
- Localized child-window title assertions passed.
- Native platform device verification was not performed.
