### PR TITLE
fix(android): restore notification permission prompt on startup

### DIFF
--- a/ui/flutter/lib/app/application/android_foreground_service.dart
+++ b/ui/flutter/lib/app/application/android_foreground_service.dart
@@ -28,6 +28,13 @@ class AndroidForegroundService {
       ),
     );
 
+    // Android 13+ requires runtime permission to show the service notification.
+    // A denial only hides it from the notification drawer; the service can run.
+    final permission = await FlutterForegroundTask.checkNotificationPermission();
+    if (permission == NotificationPermission.denied) {
+      await FlutterForegroundTask.requestNotificationPermission();
+    }
+
     if (await FlutterForegroundTask.isRunningService) {
       _throwOnFailure(await FlutterForegroundTask.restartService());
       return;


### PR DESCRIPTION
Android 13+ installations no longer receive a notification permission prompt at startup because flutter_foreground_task removed its automatic request in version 8.8.0. This leaves the background-service notification hidden until users enable notifications in system settings.

Check notification permission during Android foreground-service initialization and request it when denied. Already granted or permanently denied permissions do not trigger a request, and denying permission still allows the service to start.

Validation: targeted Flutter analysis and `git diff --check` passed. The permission dialog and background downloads have not been verified on an Android device.

Fixes #1484
