### PR TITLE
fix(windows): use bundled PNG for notification header icon

### DIFF
--- a/ui/flutter/lib/app/application/app_notification_controller.dart
+++ b/ui/flutter/lib/app/application/app_notification_controller.dart
@@ -2,10 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as path;
 
 import '../../core/common/task_event.dart';
 import '../../core/libgopeed_boot.dart';
@@ -57,18 +56,23 @@ class AppNotificationController extends AsyncNotifier<AppNotificationState> {
     String? windowsIconPath;
     try {
       if (Util.isWindows()) {
-        // Windows reads the toast header icon through the registered IconUri.
-        // Use a PNG in persistent storage so notification history can still
-        // resolve it after the app exits or temporary files are cleaned up.
-        final byteData = await rootBundle.load('assets/icon/icon_512.png');
-        final supportDir = await getApplicationSupportDirectory();
-        final file = File('${supportDir.path}/notification_icon.png');
-        await file.parent.create(recursive: true);
-        await file.writeAsBytes(
-          byteData.buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
-          flush: true,
+        // Windows requires a file path for IconUri, so use the bundled PNG
+        // beside the executable rather than copying it to another directory.
+        final file = File(
+          path.join(
+            path.dirname(Platform.resolvedExecutable),
+            'data',
+            'flutter_assets',
+            'assets',
+            'icon',
+            'icon_512.png',
+          ),
         );
-        windowsIconPath = file.absolute.path;
+        if (await file.exists()) {
+          windowsIconPath = file.absolute.path;
+        } else {
+          logger.w('Windows notification icon not found: ${file.path}');
+        }
       }
     } catch (error, stackTrace) {
       logger.w('prepare Windows notification icon failed', error, stackTrace);

--- a/ui/flutter/lib/app/application/app_notification_controller.dart
+++ b/ui/flutter/lib/app/application/app_notification_controller.dart
@@ -10,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../core/common/task_event.dart';
 import '../../core/libgopeed_boot.dart';
 import '../../l10n/l10n.dart';
+import '../../util/log_util.dart';
 import '../../util/util.dart';
 import 'app_runtime_controller.dart';
 
@@ -56,13 +57,22 @@ class AppNotificationController extends AsyncNotifier<AppNotificationState> {
     String? windowsIconPath;
     try {
       if (Util.isWindows()) {
-        final byteData = await rootBundle.load('assets/icon/icon.ico');
-        final tempDir = await getTemporaryDirectory();
-        final file = File('${tempDir.path}/notification_icon.ico');
-        await file.writeAsBytes(byteData.buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes));
-        windowsIconPath = file.path;
+        // Windows reads the toast header icon through the registered IconUri.
+        // Use a PNG in persistent storage so notification history can still
+        // resolve it after the app exits or temporary files are cleaned up.
+        final byteData = await rootBundle.load('assets/icon/icon_512.png');
+        final supportDir = await getApplicationSupportDirectory();
+        final file = File('${supportDir.path}/notification_icon.png');
+        await file.parent.create(recursive: true);
+        await file.writeAsBytes(
+          byteData.buffer.asUint8List(byteData.offsetInBytes, byteData.lengthInBytes),
+          flush: true,
+        );
+        windowsIconPath = file.absolute.path;
       }
-    } catch (_) {}
+    } catch (error, stackTrace) {
+      logger.w('prepare Windows notification icon failed', error, stackTrace);
+    }
 
     final windows = WindowsInitializationSettings(
       appName: 'Gopeed',


### PR DESCRIPTION
Windows download notifications currently register a temporary ICO file as the toast header icon. Register the existing bundled PNG directly instead, using its absolute path relative to Platform.resolvedExecutable: data/flutter_assets/assets/icon/icon_512.png.

Check that the image exists before initializing the notification plugin and log missing-file or path-resolution errors. No asset copying, directory creation, or file writes are needed. The sender identity and notification body layout remain unchanged.

Validation:
- `flutter analyze` passes.
- Dart formatting and `git diff --check` pass.
- Confirmed the bundled PNG asset declaration and the data/flutter_assets installation layout in windows/CMakeLists.txt.
- Windows compilation and visual verification are pending because the development host is macOS. Restart the updated application and complete/fail a download to verify the header icon and Notification Center icon, including when launched from a different working directory.

This is independent of the macOS authorization fix in #1498.
