### PR TITLE
fix(ui): show downloaded bytes for tasks with unknown size

### DIFF
--- a/ui/flutter/lib/features/tasks/presentation/widgets/task_card/task_card_parts.dart
+++ b/ui/flutter/lib/features/tasks/presentation/widgets/task_card/task_card_parts.dart
@@ -95,7 +95,11 @@ class TaskCardFooter extends StatelessWidget {
         children: [
           Expanded(
             child: Text(
-              task.total != null ? '${task.downloaded} / ${task.total}' : context.l10n.unknownSize,
+              task.total != null
+                  ? '${task.downloaded} / ${task.total}'
+                  : task.downloadedBytes == 0
+                  ? context.l10n.unknownSize
+                  : task.downloaded,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(color: leftColor, fontSize: 10, height: 1),


### PR DESCRIPTION
Tasks with an unknown total size now show the downloaded amount once data starts arriving, while retaining “Unknown size” when the downloaded byte count is zero. Tasks with a known total continue to show downloaded / total. This applies to both desktop and mobile task cards.

Validation: Dart formatting, targeted Flutter analysis, and git diff --check passed.
